### PR TITLE
Remove reference to row major ordering

### DIFF
--- a/mat64/dense_arithmetic.go
+++ b/mat64/dense_arithmetic.go
@@ -336,7 +336,6 @@ func (m *Dense) Mul(a, b Matrix) {
 				panic(ErrNoEngine)
 			}
 			blasEngine.Dgemm(
-				blas.RowMajor,
 				blas.NoTrans, blas.NoTrans,
 				ar, bc, ac,
 				1.,

--- a/mat64/lq.go
+++ b/mat64/lq.go
@@ -114,8 +114,8 @@ func (f LQFactor) applyQTo(x *Dense, trans bool) {
 			sub.View(x, k, 0, m-k, n)
 
 			blasEngine.Dgemv(
-				blas.ColMajor, blas.NoTrans,
-				n, m-k,
+				blas.Trans,
+				m-k, n,
 				1, sub.mat.Data, sub.mat.Stride,
 				hh, 1,
 				0, proj, 1,
@@ -133,8 +133,8 @@ func (f LQFactor) applyQTo(x *Dense, trans bool) {
 			sub.View(x, k, 0, m-k, n)
 
 			blasEngine.Dgemv(
-				blas.ColMajor, blas.NoTrans,
-				n, m-k,
+				blas.Trans,
+				m-k, n,
 				1, sub.mat.Data, sub.mat.Stride,
 				hh, 1,
 				0, proj, 1,
@@ -171,7 +171,7 @@ func (f LQFactor) Solve(b *Dense) (x *Dense) {
 		lq.Set(i, i, lDiag[i])
 	}
 	blasEngine.Dtrsm(
-		blas.RowMajor, blas.Left, blas.Lower, blas.NoTrans, blas.NonUnit,
+		blas.Left, blas.Lower, blas.NoTrans, blas.NonUnit,
 		bm, bn,
 		1, lq.mat.Data, lq.mat.Stride,
 		x.mat.Data, x.mat.Stride,

--- a/mat64/mul_test.go
+++ b/mat64/mul_test.go
@@ -111,7 +111,6 @@ func TestMul(t *testing.T) {
 
 		// Get correct matrix multiply answer from Dgemm
 		blasEngine.Dgemm(
-			blas.RowMajor,
 			blas.NoTrans, blas.NoTrans,
 			ar, bc, ac,
 			1.,

--- a/mat64/vec.go
+++ b/mat64/vec.go
@@ -81,7 +81,6 @@ func (m *Vec) Mul(a, b Matrix) {
 	if a, ok := a.(RawMatrixer); ok {
 		amat := a.RawMatrix()
 		blasEngine.Dgemv(
-			blas.RowMajor,
 			blas.NoTrans,
 			ar, ac,
 			1.,


### PR DESCRIPTION
This brings mat64 up-to-date with the recent gonum/blas changes.

@dane-unltd please review the change to `LQFactor.applyQTo()`.
