### PR TITLE
Remove Submatrix and Submatrixer

### DIFF
--- a/mat64/dense.go
+++ b/mat64/dense.go
@@ -20,10 +20,9 @@ var (
 	_ Vectorer     = matrix
 	_ VectorSetter = matrix
 
-	_ Cloner      = matrix
-	_ Viewer      = matrix
-	_ Submatrixer = matrix
-	_ RowViewer   = matrix
+	_ Cloner    = matrix
+	_ Viewer    = matrix
+	_ RowViewer = matrix
 
 	_ Adder     = matrix
 	_ Suber     = matrix
@@ -183,12 +182,6 @@ func (m *Dense) View(a Matrix, i, j, r, c int) {
 	m.mat.Data = m.mat.Data[i*m.mat.Stride+j : (i+r-1)*m.mat.Stride+(j+c)]
 	m.mat.Rows = r
 	m.mat.Cols = c
-}
-
-func (m *Dense) Submatrix(a Matrix, i, j, r, c int) {
-	// This is probably a bad idea, but for the moment, we do it.
-	m.View(a, i, j, r, c)
-	m.Clone(m)
 }
 
 func (m *Dense) Reset() {

--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -100,15 +100,6 @@ type Viewer interface {
 	View(a Matrix, i, j, r, c int)
 }
 
-// A Submatrixer can extract a copy of submatrix from a into the receiver, starting at row i,
-// column j and extending r rows and c columns. If i or j are out of range, or r or c extend
-// beyond the bounds of the matrix Submatrix will panic with ErrIndexOutOfRange. There is no
-// restriction on the shape of the receiver but changes in the elements of the submatrix must
-// not be reflected in the original.
-type Submatrixer interface {
-	Submatrix(a Matrix, i, j, r, c int)
-}
-
 // A Normer can return the specified matrix norm, o of the matrix represented by the receiver.
 //
 // Valid order values are:


### PR DESCRIPTION
Submatrix(a, i, j, r, c) is trivially implemented as `m.View(a, i, j, r, c); m.Clone(m)`, and we do not provide the Copier equivalent which is arguable more useful.
