### PR TITLE
only do coverage when using a gonum branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
  - go build -x -v ./...
  - go test -x -v ./...
  - diff <(gofmt -d .) <("")
- - bash test-coverage.sh
+ - if [[ $TRAVIS_SECURE_ENV_VARS ]]; then bash test-coverage.sh; fi
  
 
 after_failure: failure


### PR DESCRIPTION
Travis doesn't allow secure env variables (such as the coveralls api key) to be used when merging a fork.  This change avoids doing coverage under that circumstance, so that tests still run.
