### PR TITLE
Fix RawMatrix API

### DIFF
--- a/mat64/dense.go
+++ b/mat64/dense.go
@@ -50,8 +50,8 @@ var (
 	_ Equaler       = matrix
 	_ ApproxEqualer = matrix
 
-	_ RawMatrixUser = matrix
-	_ RawMatrixer   = matrix
+	_ RawMatrixSetter = matrix
+	_ RawMatrixer     = matrix
 )
 
 type Dense struct {
@@ -80,7 +80,7 @@ func DenseCopyOf(a Matrix) *Dense {
 	return d
 }
 
-func (m *Dense) UseRawMatrix(b RawMatrix) { m.mat = b }
+func (m *Dense) SetRawMatrix(b RawMatrix) { m.mat = b }
 
 func (m *Dense) RawMatrix() RawMatrix { return m.mat }
 

--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -258,10 +258,10 @@ type RawMatrix struct {
 	Data       []float64
 }
 
-// A RawMatrixUser can directly attach a RawMatrix representation. There is no restriction on the shape of the
-// receiver. Changes to the receiver's elements will be reflected in the RawMatrix.Data.
-type RawMatrixUser interface {
-	UseRawMatrix(a RawMatrix)
+// A RawMatrixSetter can set the underlying RawMatrix used by the reciever. There is no restriction
+// on the shape of the receiver. Changes to the receiver's elements will be reflected in the RawMatrix.Data.
+type RawMatrixSetter interface {
+	SetRawMatrix(a RawMatrix)
 }
 
 // A RawMatrixer can return a RawMatrix representation of the receiver. Changes to the RawMatrix.Data


### PR DESCRIPTION
- RawMatrix.Matrix was a mistake and is removed.
- Load has an implication that the underlying RawMatrix would not change, this was not true, so change the name and update the docs.
