### PR TITLE
Fix benchmark for PreMulDense

### DIFF
--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -1202,16 +1202,17 @@ func denseMulBench(b *testing.B, size int, rho float64) {
 	}
 }
 
-func BenchmarkPreMulDense100Half(b *testing.B)        { denseMulBench(b, 100, 0.5) }
-func BenchmarkPreMulDense100Tenth(b *testing.B)       { denseMulBench(b, 100, 0.1) }
-func BenchmarkPreMulDense1000Half(b *testing.B)       { denseMulBench(b, 1000, 0.5) }
-func BenchmarkPreMulDense1000Tenth(b *testing.B)      { denseMulBench(b, 1000, 0.1) }
-func BenchmarkPreMulDense1000Hundredth(b *testing.B)  { denseMulBench(b, 1000, 0.01) }
-func BenchmarkPreMulDense1000Thousandth(b *testing.B) { denseMulBench(b, 1000, 0.001) }
+func BenchmarkPreMulDense100Half(b *testing.B)        { densePreMulBench(b, 100, 0.5) }
+func BenchmarkPreMulDense100Tenth(b *testing.B)       { densePreMulBench(b, 100, 0.1) }
+func BenchmarkPreMulDense1000Half(b *testing.B)       { densePreMulBench(b, 1000, 0.5) }
+func BenchmarkPreMulDense1000Tenth(b *testing.B)      { densePreMulBench(b, 1000, 0.1) }
+func BenchmarkPreMulDense1000Hundredth(b *testing.B)  { densePreMulBench(b, 1000, 0.01) }
+func BenchmarkPreMulDense1000Thousandth(b *testing.B) { densePreMulBench(b, 1000, 0.001) }
 func densePreMulBench(b *testing.B, size int, rho float64) {
 	b.StopTimer()
 	a, _ := randDense(size, rho, rand.NormFloat64)
 	d, _ := randDense(size, rho, rand.NormFloat64)
+	wd := NewDense(size, size, nil)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		wd.Mul(a, d)

--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -1212,7 +1212,7 @@ func densePreMulBench(b *testing.B, size int, rho float64) {
 	b.StopTimer()
 	a, _ := randDense(size, rho, rand.NormFloat64)
 	d, _ := randDense(size, rho, rand.NormFloat64)
-	wd := NewDense(size, size, nil)
+	wd = NewDense(size, size, nil)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		wd.Mul(a, d)


### PR DESCRIPTION
It looks like the code was copy-pasted, but the function it calls is
the same as the BenchmarkMulDense* functions.  The densePreMulBench
function also had an error in it.