### PR TITLE
mat64: implement Binary(Un)Marshaler

### DIFF
--- a/mat64/dense.go
+++ b/mat64/dense.go
@@ -5,6 +5,9 @@
 package mat64
 
 import (
+	"bytes"
+	"encoding/binary"
+
 	"github.com/gonum/blas/blas64"
 )
 
@@ -496,4 +499,74 @@ func (m *Dense) Augment(a, b Matrix) {
 	m.Copy(a)
 	w := m.View(0, ac, br, bc).(*Dense)
 	w.Copy(b)
+}
+
+// MarshalBinary encodes the receiver into a binary form and returns the result.
+//
+// Dense is little-endian encoded as follows:
+//  0 -  8  number of rows    (int64)
+//  8 - 16  number of columns (int64)
+// 16 - ..  matrix data elements (float64)
+//          [0,0] [0,1] ... [0,ncols-1]
+//          [1,0] [1,1] ... [1,ncols-1]
+//          ...
+//          [nrows-1,0] ... [nrows-1,ncols-1]
+func (m Dense) MarshalBinary() ([]byte, error) {
+	buf := bytes.NewBuffer(make([]byte, 0, m.mat.Rows*m.mat.Cols*sizeFloat64+2*sizeInt64))
+	err := binary.Write(buf, defaultEndian, int64(m.mat.Rows))
+	if err != nil {
+		return nil, err
+	}
+	err = binary.Write(buf, defaultEndian, int64(m.mat.Cols))
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < m.mat.Rows; i++ {
+		for _, v := range m.rowView(i) {
+			err = binary.Write(buf, defaultEndian, v)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return buf.Bytes(), err
+}
+
+// UnmarshalBinary decodes the binary form into the receiver.
+// It panics if the receiver is a non-zero Dense matrix.
+//
+// See MarshalBinary for the on-disk layout.
+func (m *Dense) UnmarshalBinary(data []byte) error {
+	if !m.isZero() {
+		panic("mat64: unmarshal into non-zero matrix")
+	}
+
+	buf := bytes.NewReader(data)
+	var rows int64
+	err := binary.Read(buf, defaultEndian, &rows)
+	if err != nil {
+		return err
+	}
+	var cols int64
+	err = binary.Read(buf, defaultEndian, &cols)
+	if err != nil {
+		return err
+	}
+
+	m.mat.Rows = int(rows)
+	m.mat.Cols = int(cols)
+	m.mat.Stride = int(cols)
+	m.capRows = int(rows)
+	m.capCols = int(cols)
+	m.mat.Data = use(m.mat.Data, m.mat.Rows*m.mat.Cols)
+
+	for i := range m.mat.Data {
+		err = binary.Read(buf, defaultEndian, &m.mat.Data[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
 }

--- a/mat64/io.go
+++ b/mat64/io.go
@@ -1,0 +1,18 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mat64
+
+import (
+	"encoding/binary"
+)
+
+var (
+	littleEndian  = binary.LittleEndian
+	bigEndian     = binary.BigEndian
+	defaultEndian = littleEndian
+
+	sizeInt64   = binary.Size(int64(0))
+	sizeFloat64 = binary.Size(float64(0))
+)

--- a/mat64/io_test.go
+++ b/mat64/io_test.go
@@ -1,0 +1,35 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mat64
+
+import (
+	"gopkg.in/check.v1"
+)
+
+func (s *S) TestDenseRW(c *check.C) {
+	for i, test := range []*Dense{
+		NewDense(0, 0, []float64{}),
+		NewDense(2, 2, []float64{1, 2, 3, 4}),
+		NewDense(2, 3, []float64{1, 2, 3, 4, 5, 6}),
+		NewDense(3, 2, []float64{1, 2, 3, 4, 5, 6}),
+		NewDense(3, 3, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}),
+		NewDense(3, 3, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}).View(0, 0, 2, 2).(*Dense),
+		NewDense(3, 3, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}).View(1, 1, 2, 2).(*Dense),
+		NewDense(3, 3, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}).View(0, 1, 3, 2).(*Dense),
+	} {
+		buf, err := test.MarshalBinary()
+		c.Check(err, check.Equals, nil, check.Commentf("error encoding test #%d: %v\n", i, err))
+
+		nrows, ncols := test.Dims()
+		sz := nrows*ncols*sizeFloat64 + 2*sizeInt64
+		c.Check(len(buf), check.Equals, sz, check.Commentf("encoded size test #%d: want=%d got=%d\n", i, sz, len(buf)))
+
+		var got Dense
+		err = got.UnmarshalBinary(buf)
+		c.Check(err, check.Equals, nil, check.Commentf("error decoding test #%d: %v\n", i, err))
+
+		c.Check(got.Equals(test), check.Equals, true, check.Commentf("r/w test #%d failed\nwant=%#v\n got=%#v\n", i, test, &got))
+	}
+}


### PR DESCRIPTION
implement `encoding.BinaryMarshaler` and `encoding.BinaryUnmarshaler` for:
- `mat64.Dense`
- `mat64.Eigen`
- `mat64.LQ`
- `mat64.LU`
- `mat64.QR`
- `mat64.SVD`
- `mat64.Triangular`
- `mat64.Vec`

add tests.
