### PR TITLE
Remove receiver zeroing in Pow test

### DIFF
--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -792,9 +792,6 @@ func (s *S) TestPow(c *check.C) {
 					d[i] = math.NaN()
 				}
 				*a = *NewDense(10, 10, d).View(1, 1, 3, 3).(*Dense)
-				for i := 0; i < a.mat.Rows; i++ {
-					zero(a.mat.Data[i*a.mat.Stride : i*a.mat.Stride+a.mat.Cols])
-				}
 			},
 		},
 		{
@@ -812,9 +809,6 @@ func (s *S) TestPow(c *check.C) {
 					d[i] = math.NaN()
 				}
 				*a = *NewDense(10, 10, d).View(1, 1, 3, 3).(*Dense)
-				for i := 0; i < a.mat.Rows; i++ {
-					zero(a.mat.Data[i*a.mat.Stride : i*a.mat.Stride+a.mat.Cols])
-				}
 			},
 		},
 	} {


### PR DESCRIPTION
blas/native now has the same behaviour as blas/cgo wrt beta == 0 and there are NaN elements, so we don't need to pre-zero where there are NaNs in the matrix.