### PR TITLE
Add useZeroed partner to use

### DIFF
--- a/mat64/dense.go
+++ b/mat64/dense.go
@@ -199,12 +199,11 @@ func (m *Dense) Grow(r, c int) Matrix {
 			Rows:   r,
 			Cols:   c,
 			Stride: c,
-			Data:   use(m.mat.Data, r*c),
+			// We zero because we don't know how the matrix will be used.
+			// In other places, the mat is immediately filled with a result;
+			// this is not the case here.
+			Data: useZeroed(m.mat.Data, r*c),
 		}
-		// We zero here because we don't know how the matrix will be used.
-		// In other places, the mat is immediately filled with a result;
-		// this is not the case here.
-		zero(t.mat.Data[:cap(t.mat.Data)])
 	case r > m.capRows || c > m.capCols:
 		cr := max(r, m.capRows)
 		cc := max(c, m.capCols)
@@ -300,13 +299,6 @@ func (m *Dense) Copy(a Matrix) (r, c int) {
 	}
 
 	return r, c
-}
-
-func zero(f []float64) {
-	f[0] = 0
-	for i := 1; i < len(f); {
-		i += copy(f[i:], f[:i])
-	}
 }
 
 func (m *Dense) U(a Matrix) {

--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -263,9 +263,11 @@ func (s *S) TestGrow(c *check.C) {
 	// Test grow uses existing data slice when matrix is zero size.
 	v.Reset()
 	p, l := &v.mat.Data[:1][0], cap(v.mat.Data)
+	*p = 1
 	v = v.Grow(5, 5).(*Dense)
 	c.Check(&v.mat.Data[:1][0], check.Equals, p)
 	c.Check(cap(v.mat.Data), check.Equals, l)
+	c.Check(v.At(0, 0), check.Equals, 0.)
 }
 
 func (s *S) TestAdd(c *check.C) {

--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -430,3 +430,23 @@ func use(f []float64, l int) []float64 {
 	}
 	return make([]float64, l)
 }
+
+// useZeroed returns a float64 slice with l elements, using f if it
+// has the necessary capacity, otherwise creating a new slice. The
+// elements of the returned slice are guaranteed to be zero.
+func useZeroed(f []float64, l int) []float64 {
+	if l <= cap(f) {
+		f = f[:l]
+		zero(f)
+		return f
+	}
+	return make([]float64, l)
+}
+
+// zero does a fast zeroing of the given slice's elements.
+func zero(f []float64) {
+	f[0] = 0
+	for i := 1; i < len(f); {
+		i += copy(f[i:], f[:i])
+	}
+}


### PR DESCRIPTION
The choice of a separate function rather than a bool in use is highlight when the returned slice is expected to be zeroed; a true is likely to be ignored when reading.

Also added test of zeroing and moved zero into matrix.go.