### PR TITLE
Fixed incorrect check in Grow.

### DIFF
--- a/mat64/dense.go
+++ b/mat64/dense.go
@@ -216,7 +216,7 @@ func (m *Dense) Grow(r, c int) Matrix {
 	if r < 0 || c < 0 {
 		panic(ErrIndexOutOfRange)
 	}
-	if r == 0 || c == 0 {
+	if r == 0 && c == 0 {
 		return m
 	}
 


### PR DESCRIPTION
Grow has a fast path if the expansion is zero. However, the fast-path is currently checked as an Or, but the fast path is only when both are zero. It is definitely possible to grow in one dimension and not the other.