### PR TITLE
Fix symmetric Inner

### DIFF
--- a/mat64/inner.go
+++ b/mat64/inner.go
@@ -35,7 +35,7 @@ func Inner(x []float64, A Matrix, y []float64) float64 {
 			}
 			yi := y[i]
 			if i != n-1 && yi != 0 {
-				sum += yi * asm.DdotInc(bmat.Data[(i+1)*bmat.Stride+i:], x[i+1:], uintptr(n-i), uintptr(bmat.Stride), 1, 0, 0)
+				sum += yi * asm.DdotUnitary(bmat.Data[i*bmat.Stride+i+1:i*bmat.Stride+n], x[i+1:])
 			}
 		}
 	case RawMatrixer:

--- a/mat64/inner_test.go
+++ b/mat64/inner_test.go
@@ -6,6 +6,7 @@ package mat64
 
 import (
 	"math"
+	"math/rand"
 	"testing"
 
 	"github.com/gonum/blas/blas64"
@@ -94,6 +95,13 @@ func (s *S) TestInnerSym(c *check.C) {
 	m := NewDense(n, n, data)
 	ans := Inner(x, m, y)
 	sym := NewSymDense(n, data)
+	// scramble the lower half of data to ensure it is not used
+	for i := 1; i < n; i++ {
+		for j := 0; j < i; j++ {
+			data[i*n+j] = rand.Float64()
+		}
+	}
+
 	if math.Abs(Inner(x, sym, y)-ans) > 1e-14 {
 		c.Error("inner different symmetric and dense")
 	}


### PR DESCRIPTION
The previous implementation dotted along the row with x and the column with y. This is incorrect, because the data is only valid in the upper triangular half of the matrix. Instead, dot along the row for both x and y.