### PR TITLE
Fixing bug in colView in Dense

### DIFF
--- a/mat64/dense.go
+++ b/mat64/dense.go
@@ -132,7 +132,7 @@ func (m *Dense) ColView(j int) *Vector {
 	return &Vector{
 		mat: blas64.Vector{
 			Inc:  m.mat.Stride,
-			Data: m.mat.Data[j : m.mat.Rows*m.mat.Stride+j],
+			Data: m.mat.Data[j : (m.mat.Rows-1)*m.mat.Stride+j+1],
 		},
 		n: m.mat.Rows,
 	}

--- a/mat64/matrix_test.go
+++ b/mat64/matrix_test.go
@@ -38,9 +38,12 @@ func panics(fn func()) (panicked bool, message string) {
 }
 
 func flatten(f [][]float64) (r, c int, d []float64) {
+	collected := make([]float64, 0)
 	for _, r := range f {
-		d = append(d, r...)
+		collected = append(collected, r...)
 	}
+	d = make([]float64, len(collected))
+	copy(d, collected[:len(d)])
 	return len(f), len(f[0]), d
 }
 


### PR DESCRIPTION
Without the fix, code that uses colView crashes, unless the underlying []float64 has cap() > len().