### PR TITLE
Make flatten stricter in data preparation

### DIFF
--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -268,8 +268,13 @@ func (s *S) TestRowColView(c *check.C) {
 			},
 		},
 	} {
-		m := NewDense(flatten(test.mat))
-		rows, cols := m.Dims()
+		// This over cautious approach to building a matrix data
+		// slice is to ensure that changes to flatten in the future
+		// do not mask a regression to the issue identified in
+		// gonum/matrix#110.
+		rows, cols, flat := flatten(test.mat)
+		m := NewDense(rows, cols, flat[:len(flat):len(flat)])
+
 		c.Check(func() { m.RowView(-1) }, check.PanicMatches, ErrRowAccess.Error())
 		c.Check(func() { m.RowView(rows) }, check.PanicMatches, ErrRowAccess.Error())
 		c.Check(func() { m.ColView(-1) }, check.PanicMatches, ErrColAccess.Error())

--- a/mat64/matrix_test.go
+++ b/mat64/matrix_test.go
@@ -38,13 +38,19 @@ func panics(fn func()) (panicked bool, message string) {
 }
 
 func flatten(f [][]float64) (r, c int, d []float64) {
-	collected := make([]float64, 0)
-	for _, r := range f {
-		collected = append(collected, r...)
+	r = len(f)
+	if r == 0 {
+		panic("bad test: no row")
 	}
-	d = make([]float64, len(collected))
-	copy(d, collected[:len(d)])
-	return len(f), len(f[0]), d
+	c = len(f[0])
+	d = make([]float64, 0, r*c)
+	for _, row := range f {
+		if len(row) != c {
+			panic("bad test: ragged input")
+		}
+		d = append(d, row...)
+	}
+	return r, c, d
 }
 
 func unflatten(r, c int, d []float64) [][]float64 {


### PR DESCRIPTION
* Panic on ragged input or rowless data.
* Build data slice that has exact cap - this is what NewDense does, so  we should match that.

This change catches a bug in (*Dense).ColView that will be fixed with a PR to be merged later today (#110).