### PR TITLE
mat64: improve error handling

### DIFF
--- a/mat64/cholesky.go
+++ b/mat64/cholesky.go
@@ -13,6 +13,8 @@ import (
 	"github.com/gonum/internal/asm"
 )
 
+const badTriangle = "mat64: invalid triangle"
+
 // Cholesky calculates the Cholesky decomposition of the matrix A and returns
 // whether the matrix is positive definite. The returned matrix is either a
 // lower triangular matrix such that A = L * L^T or an upper triangular matrix
@@ -99,7 +101,7 @@ func (m *Dense) SolveCholesky(t *Triangular, b Matrix) {
 		blas64.Trsm(blas.Left, blas.NoTrans, 1, t.mat, m.mat)
 		blas64.Trsm(blas.Left, blas.Trans, 1, t.mat, m.mat)
 	default:
-		panic("mat64: invalid triangle")
+		panic(badTriangle)
 	}
 }
 
@@ -125,6 +127,6 @@ func (m *Dense) SolveTri(a *Triangular, trans bool, b Matrix) {
 	case blas.Upper, blas.Lower:
 		blas64.Trsm(blas.Left, t, 1, a.mat, m.mat)
 	default:
-		panic("mat64: invalid triangle")
+		panic(badTriangle)
 	}
 }

--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -684,8 +684,8 @@ func (s *S) TestMulTrans(c *check.C) {
 					br, _ := bCopy.Dims()
 					if ac != br {
 						// check that both calls error and that the same error returns
-						c.Check(func() { temp.Mul(matInterface(&aCopy), matInterface(&bCopy)) }, check.PanicMatches, string(ErrShape), check.Commentf("Test Mul %d", i))
-						c.Check(func() { temp.MulTrans(a, aTrans, b, bTrans) }, check.PanicMatches, string(ErrShape), check.Commentf("Test MulTrans %d", i))
+						c.Check(func() { temp.Mul(matInterface(&aCopy), matInterface(&bCopy)) }, check.PanicMatches, ErrShape.Error(), check.Commentf("Test Mul %d", i))
+						c.Check(func() { temp.MulTrans(a, aTrans, b, bTrans) }, check.PanicMatches, ErrShape.Error(), check.Commentf("Test MulTrans %d", i))
 						continue
 					}
 

--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -365,8 +365,11 @@ type Panicker func()
 func Maybe(fn Panicker) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			var ok bool
-			if err, ok = r.(Error); ok {
+			if e, ok := r.(Error); ok {
+				if e.string == "" {
+					panic("mat64: invalid error")
+				}
+				err = e
 				return
 			}
 			panic(r)
@@ -385,6 +388,9 @@ func MaybeFloat(fn FloatPanicker) (f float64, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if e, ok := r.(Error); ok {
+				if e.string == "" {
+					panic("mat64: invalid error")
+				}
 				err = e
 				return
 			}
@@ -395,23 +401,23 @@ func MaybeFloat(fn FloatPanicker) (f float64, err error) {
 }
 
 // Type Error represents matrix handling errors. These errors can be recovered by Maybe wrappers.
-type Error string
+type Error struct{ string }
 
-func (err Error) Error() string { return string(err) }
+func (err Error) Error() string { return err.string }
 
-const (
-	ErrIndexOutOfRange = Error("mat64: index out of range")
-	ErrRowAccess       = Error("mat64: row index out of range")
-	ErrColAccess       = Error("mat64: column index out of range")
-	ErrZeroLength      = Error("mat64: zero length in matrix definition")
-	ErrRowLength       = Error("mat64: row length mismatch")
-	ErrColLength       = Error("mat64: col length mismatch")
-	ErrSquare          = Error("mat64: expect square matrix")
-	ErrNormOrder       = Error("mat64: invalid norm order for matrix")
-	ErrSingular        = Error("mat64: matrix is singular")
-	ErrShape           = Error("mat64: dimension mismatch")
-	ErrIllegalStride   = Error("mat64: illegal stride")
-	ErrPivot           = Error("mat64: malformed pivot list")
+var (
+	ErrIndexOutOfRange = Error{"mat64: index out of range"}
+	ErrRowAccess       = Error{"mat64: row index out of range"}
+	ErrColAccess       = Error{"mat64: column index out of range"}
+	ErrZeroLength      = Error{"mat64: zero length in matrix definition"}
+	ErrRowLength       = Error{"mat64: row length mismatch"}
+	ErrColLength       = Error{"mat64: col length mismatch"}
+	ErrSquare          = Error{"mat64: expect square matrix"}
+	ErrNormOrder       = Error{"mat64: invalid norm order for matrix"}
+	ErrSingular        = Error{"mat64: matrix is singular"}
+	ErrShape           = Error{"mat64: dimension mismatch"}
+	ErrIllegalStride   = Error{"mat64: illegal stride"}
+	ErrPivot           = Error{"mat64: malformed pivot list"}
 )
 
 func min(a, b int) int {

--- a/mat64/matrix_test.go
+++ b/mat64/matrix_test.go
@@ -83,7 +83,7 @@ func (s *S) TestMaybe(c *check.C) {
 			true,
 		},
 		{
-			func() { panic(Error("panic")) },
+			func() { panic(Error{"panic"}) },
 			false,
 		},
 	} {

--- a/mat64/symmetric.go
+++ b/mat64/symmetric.go
@@ -13,9 +13,7 @@ var (
 	_ RawSymmetricer = symDense
 )
 
-const (
-	ErrUplo = "mat64: blas64.Symmetric not upper"
-)
+const badSymTriangle = "mat64: blas64.Symmetric not upper"
 
 // SymDense is a symmetric matrix that uses Dense storage.
 type SymDense struct {
@@ -120,7 +118,7 @@ func (s *SymDense) CopySym(a Symmetric) int {
 	case RawSymmetricer:
 		amat := a.RawSymmetric()
 		if amat.Uplo != blas.Upper {
-			panic(ErrUplo)
+			panic(badSymTriangle)
 		}
 		for i := 0; i < n; i++ {
 			copy(s.mat.Data[i*s.mat.Stride+i:i*s.mat.Stride+n], amat.Data[i*amat.Stride+i:i*amat.Stride+n])


### PR DESCRIPTION
Previously, we used Error string as potentially recoverable mat64 failures (clients can obviously choose to recover and panics we call, but these are the one we think are not too serious). That approach allowed clients to create new mat64.Errors.

This change prevents clients from creating new mat64.Error values.