### PR TITLE
Fix slice size in TriDense.Cholesky()

### DIFF
--- a/mat64/cholesky.go
+++ b/mat64/cholesky.go
@@ -61,7 +61,7 @@ func (t *TriDense) Cholesky(a *SymDense, upper bool) (ok bool) {
 		for j := 0; j < n; j++ {
 			var d float64
 			for k := 0; k < j; k++ {
-				s := asm.DdotUnitary(mat[k*stride:k*stride+(n-k)], mat[j*stride:j*stride+(n-k)])
+				s := asm.DdotUnitary(mat[k*stride:k*stride+k], mat[j*stride:j*stride+k])
 				s = (a.at(j, k) - s) / t.at(k, k)
 				t.set(j, k, s)
 				d += s * s

--- a/mat64/cholesky_test.go
+++ b/mat64/cholesky_test.go
@@ -4,7 +4,11 @@
 
 package mat64
 
-import "gopkg.in/check.v1"
+import (
+	"math"
+
+	"gopkg.in/check.v1"
+)
 
 func (s *S) TestCholesky(c *check.C) {
 	for _, t := range []struct {
@@ -76,6 +80,27 @@ func (s *S) TestCholesky(c *check.C) {
 				2, 0.5, 0.5,
 				0, 1.3228756555322954, 2.0788046015507495,
 				0, 0, 1.195228609334394,
+			}),
+			pd: true,
+		},
+		{
+			// Test case for issue #119.
+			a: NewSymDense(3, []float64{
+				4, 1, 1,
+				0, 2, 3,
+				0, 0, 6,
+			}),
+			upper: false,
+			f: NewTriDense(3, false, []float64{
+				math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(),
+			}),
+
+			want: NewTriDense(3, false, []float64{
+				2, 0, 0,
+				0.5, 1.3228756555322954, 0,
+				0.5, 2.0788046015507495, 1.195228609334394,
 			}),
 			pd: true,
 		},


### PR DESCRIPTION
What would be the best way to update the tests? Leave the existing tests and add a new function `TestIssue119()`, or change the tests to use non-zero TriDense receiver?

Fixes #119