### PR TITLE
Check Triangular match in Cholesky

### DIFF
--- a/mat64/cholesky.go
+++ b/mat64/cholesky.go
@@ -28,14 +28,23 @@ func (t *TriDense) Cholesky(a *SymDense, upper bool) (ok bool) {
 			Diag:   blas.NonUnit,
 			Data:   use(t.mat.Data, n*n),
 		}
-	} else if n != t.mat.N {
-		panic(ErrShape)
+		if upper {
+			t.mat.Uplo = blas.Upper
+		} else {
+			t.mat.Uplo = blas.Lower
+		}
+	} else {
+		if n != t.mat.N {
+			panic(ErrShape)
+		}
+		if (upper && t.mat.Uplo != blas.Upper) || (!upper && t.mat.Uplo != blas.Lower) {
+			panic(ErrTriangle)
+		}
 	}
 	mat := t.mat.Data
 	stride := t.mat.Stride
 
 	if upper {
-		t.mat.Uplo = blas.Upper
 		for j := 0; j < n; j++ {
 			var d float64
 			for k := 0; k < j; k++ {
@@ -57,7 +66,6 @@ func (t *TriDense) Cholesky(a *SymDense, upper bool) (ok bool) {
 			t.set(j, j, math.Sqrt(math.Max(d, 0)))
 		}
 	} else {
-		t.mat.Uplo = blas.Lower
 		for j := 0; j < n; j++ {
 			var d float64
 			for k := 0; k < j; k++ {

--- a/mat64/cholesky_test.go
+++ b/mat64/cholesky_test.go
@@ -74,7 +74,7 @@ func (s *S) TestCholesky(c *check.C) {
 				0, 0, 6,
 			}),
 			upper: true,
-			f:     NewTriDense(3, false, nil),
+			f:     NewTriDense(3, true, nil),
 
 			want: NewTriDense(3, true, []float64{
 				2, 0.5, 0.5,

--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -424,6 +424,7 @@ var (
 	ErrShape           = Error{"mat64: dimension mismatch"}
 	ErrIllegalStride   = Error{"mat64: illegal stride"}
 	ErrPivot           = Error{"mat64: malformed pivot list"}
+	ErrTriangle        = Error{"mat64: triangular storage mismatch"}
 )
 
 func min(a, b int) int {


### PR DESCRIPTION
If the TriDense receiver in Cholesky is non-zero, the triangular storage should match the upper input argument. This change ensures this; previously the shape of the receiver was silently overwritten.

Fixes issue 126.