### PR TITLE
mat64: omit final unused pow squaring

### DIFF
--- a/mat64/dense_arithmetic.go
+++ b/mat64/dense_arithmetic.go
@@ -709,7 +709,9 @@ func (m *Dense) Pow(a Matrix, n int) {
 		if n&1 != 0 {
 			w.Mul(&w, &tmp)
 		}
-		tmp.Mul(&tmp, &tmp)
+		if n != 1 {
+			tmp.Mul(&tmp, &tmp)
+		}
 	}
 	m.Copy(&w)
 }

--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -896,6 +896,45 @@ func (s *S) TestPow(c *check.C) {
 	}
 }
 
+func (s *S) TestPowN(c *check.C) {
+	for i, t := range []struct {
+		a    [][]float64
+		mod  func(*Dense)
+		want [][]float64
+	}{
+		{
+			a: [][]float64{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
+		},
+		{
+			a: [][]float64{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
+			mod: func(a *Dense) {
+				d := make([]float64, 100)
+				for i := range d {
+					d[i] = math.NaN()
+				}
+				*a = *NewDense(10, 10, d).View(1, 1, 3, 3).(*Dense)
+			},
+		},
+	} {
+		for n := 1; n <= 14; n++ {
+			var got, want Dense
+			if t.mod != nil {
+				t.mod(&got)
+			}
+			got.Pow(NewDense(flatten(t.a)), n)
+			want.iterativePow(NewDense(flatten(t.a)), n)
+			c.Check(got.Equals(&want), check.Equals, true, check.Commentf("Test %d", i))
+		}
+	}
+}
+
+func (m *Dense) iterativePow(a Matrix, n int) {
+	m.Clone(a)
+	for i := 1; i < n; i++ {
+		m.Mul(m, a)
+	}
+}
+
 func (s *S) TestLU(c *check.C) {
 	for i := 0; i < 100; i++ {
 		size := rand.Intn(100)
@@ -1353,6 +1392,38 @@ func expBench(b *testing.B, size int) {
 	var m Dense
 	for i := 0; i < b.N; i++ {
 		m.Exp(a)
+	}
+}
+
+func BenchmarkPow10_3(b *testing.B)   { powBench(b, 10, 3) }
+func BenchmarkPow100_3(b *testing.B)  { powBench(b, 100, 3) }
+func BenchmarkPow1000_3(b *testing.B) { powBench(b, 1000, 3) }
+func BenchmarkPow10_4(b *testing.B)   { powBench(b, 10, 4) }
+func BenchmarkPow100_4(b *testing.B)  { powBench(b, 100, 4) }
+func BenchmarkPow1000_4(b *testing.B) { powBench(b, 1000, 4) }
+func BenchmarkPow10_5(b *testing.B)   { powBench(b, 10, 5) }
+func BenchmarkPow100_5(b *testing.B)  { powBench(b, 100, 5) }
+func BenchmarkPow1000_5(b *testing.B) { powBench(b, 1000, 5) }
+func BenchmarkPow10_6(b *testing.B)   { powBench(b, 10, 6) }
+func BenchmarkPow100_6(b *testing.B)  { powBench(b, 100, 6) }
+func BenchmarkPow1000_6(b *testing.B) { powBench(b, 1000, 6) }
+func BenchmarkPow10_7(b *testing.B)   { powBench(b, 10, 7) }
+func BenchmarkPow100_7(b *testing.B)  { powBench(b, 100, 7) }
+func BenchmarkPow1000_7(b *testing.B) { powBench(b, 1000, 7) }
+func BenchmarkPow10_8(b *testing.B)   { powBench(b, 10, 8) }
+func BenchmarkPow100_8(b *testing.B)  { powBench(b, 100, 8) }
+func BenchmarkPow1000_8(b *testing.B) { powBench(b, 1000, 8) }
+func BenchmarkPow10_9(b *testing.B)   { powBench(b, 10, 9) }
+func BenchmarkPow100_9(b *testing.B)  { powBench(b, 100, 9) }
+func BenchmarkPow1000_9(b *testing.B) { powBench(b, 1000, 9) }
+
+func powBench(b *testing.B, size, n int) {
+	a, _ := randDense(size, 1, rand.NormFloat64)
+
+	b.ResetTimer()
+	var m Dense
+	for i := 0; i < b.N; i++ {
+		m.Pow(a, n)
 	}
 }
 


### PR DESCRIPTION
@btracey PTAL

```
name       old mean              new mean              delta
Pow10_3    27.6µs × (0.92,1.07)  21.1µs × (0.98,1.03)   -23.54% (p=0.000 n=10+9)
Pow100_3   2.93ms × (1.00,1.01)  2.03ms × (0.98,1.02)   -30.67% (p=0.000 n=8+10)
Pow1000_3   2.67s × (1.00,1.00)   1.75s × (0.99,1.01)  -34.33% (p=0.000 n=10+10)
Pow10_4    33.6µs × (1.00,1.00)  27.5µs × (0.98,1.03)   -18.14% (p=0.000 n=8+10)
Pow100_4   3.83ms × (0.99,1.01)  2.96ms × (0.99,1.01)    -22.80% (p=0.000 n=9+9)
Pow1000_4   3.55s × (1.00,1.01)   2.67s × (1.00,1.00)  -24.62% (p=0.000 n=10+10)
Pow10_5    34.0µs × (0.99,1.02)  28.7µs × (0.98,1.03)  -15.46% (p=0.000 n=10+10)
Pow100_5   3.83ms × (1.00,1.00)  2.97ms × (0.99,1.01)   -22.31% (p=0.000 n=10+9)
Pow1000_5   3.55s × (1.00,1.00)   2.67s × (1.00,1.00)   -24.98% (p=0.000 n=8+10)
Pow10_6    40.5µs × (1.00,1.00)  35.0µs × (1.00,1.00)    -13.38% (p=0.000 n=9+8)
Pow100_6   4.76ms × (1.00,1.00)  3.92ms × (0.99,1.01)  -17.71% (p=0.000 n=10+10)
Pow1000_6   4.43s × (1.00,1.00)   3.55s × (1.00,1.00)  -19.83% (p=0.000 n=10+10)
Pow10_7    40.7µs × (0.99,1.01)  35.9µs × (0.98,1.03)   -11.75% (p=0.000 n=9+10)
Pow100_7   4.75ms × (1.00,1.00)  3.93ms × (1.00,1.01)   -17.14% (p=0.000 n=8+10)
Pow1000_7   4.43s × (1.00,1.00)   3.55s × (1.00,1.00)  -19.93% (p=0.000 n=10+10)
Pow10_8    48.1µs × (1.00,1.00)  42.6µs × (0.98,1.03)  -11.47% (p=0.000 n=10+10)
Pow100_8   5.72ms × (1.00,1.00)  4.87ms × (1.00,1.00)    -14.92% (p=0.000 n=9+9)
Pow1000_8   5.33s × (1.00,1.00)   4.44s × (1.00,1.00)   -16.63% (p=0.000 n=8+10)
Pow10_9    40.9µs × (1.00,1.00)  35.5µs × (1.00,1.01)   -13.36% (p=0.000 n=10+9)
Pow100_9   4.76ms × (1.00,1.00)  3.93ms × (0.99,1.00)  -17.55% (p=0.000 n=10+10)
Pow1000_9   4.43s × (1.00,1.00)   3.55s × (1.00,1.00)   -19.88% (p=0.000 n=9+10)
```