### PR TITLE
mat64: reduce allocation load in pow

### DIFF
--- a/mat64/dense_arithmetic.go
+++ b/mat64/dense_arithmetic.go
@@ -702,15 +702,17 @@ func (m *Dense) Pow(a Matrix, n int) {
 	}
 
 	// Perform iterative exponentiation by squaring in work space.
-	var w, tmp Dense
+	var w, s, x Dense
 	w.Clone(a)
-	tmp.Clone(a)
+	s.Clone(a)
 	for n--; n > 0; n >>= 1 {
 		if n&1 != 0 {
-			w.Mul(&w, &tmp)
+			x.Mul(&w, &s)
+			w, x = x, w
 		}
 		if n != 1 {
-			tmp.Mul(&tmp, &tmp)
+			x.Mul(&s, &s)
+			s, x = x, s
 		}
 	}
 	m.Copy(&w)


### PR DESCRIPTION
@btracey PTAL

```
name       old mean              new mean              delta
Pow10_3    21.1µs × (0.98,1.03)  18.6µs × (0.98,1.04)   -11.76% (p=0.000 n=9+10)
Pow100_3   2.03ms × (0.98,1.02)  1.95ms × (0.99,1.01)   -4.01% (p=0.000 n=10+10)
Pow1000_3   1.75s × (0.99,1.01)   1.72s × (1.00,1.00)    -1.96% (p=0.000 n=10+9)
Pow10_4    27.5µs × (0.98,1.03)  20.7µs × (0.99,1.01)  -24.80% (p=0.000 n=10+10)
Pow100_4   2.96ms × (0.99,1.01)  2.80ms × (1.00,1.00)    -5.27% (p=0.000 n=9+10)
Pow1000_4   2.67s × (1.00,1.00)   2.58s × (1.00,1.00)    -3.49% (p=0.000 n=10+8)
Pow10_5    28.7µs × (0.98,1.03)  21.1µs × (0.98,1.03)  -26.48% (p=0.000 n=10+10)
Pow100_5   2.97ms × (0.99,1.01)  2.79ms × (1.00,1.00)    -6.22% (p=0.000 n=9+10)
Pow1000_5   2.67s × (1.00,1.00)   2.55s × (1.00,1.00)   -4.18% (p=0.000 n=10+10)
Pow10_6    35.0µs × (1.00,1.00)  25.2µs × (0.97,1.04)   -28.12% (p=0.000 n=8+10)
Pow100_6   3.92ms × (0.99,1.01)  3.75ms × (0.99,1.01)   -4.43% (p=0.000 n=10+10)
Pow1000_6   3.55s × (1.00,1.00)   3.49s × (1.00,1.00)    -1.68% (p=0.000 n=10+8)
Pow10_7    35.9µs × (0.98,1.03)  25.2µs × (0.98,1.03)  -29.89% (p=0.000 n=10+10)
Pow100_7   3.93ms × (1.00,1.01)  3.66ms × (1.00,1.00)    -6.81% (p=0.000 n=10+9)
Pow1000_7   3.55s × (1.00,1.00)   3.41s × (1.00,1.00)   -3.88% (p=0.000 n=10+10)
Pow10_8    42.6µs × (0.98,1.03)  30.6µs × (0.97,1.04)  -28.12% (p=0.000 n=10+10)
Pow100_8   4.87ms × (1.00,1.00)  4.55ms × (1.00,1.00)    -6.55% (p=0.000 n=9+10)
Pow1000_8   4.44s × (1.00,1.00)   4.27s × (1.00,1.00)   -3.75% (p=0.000 n=10+10)
Pow10_9    35.5µs × (1.00,1.01)  25.5µs × (0.97,1.04)   -28.04% (p=0.000 n=9+10)
Pow100_9   3.93ms × (0.99,1.00)  3.67ms × (1.00,1.00)   -6.57% (p=0.000 n=10+10)
Pow1000_9   3.55s × (1.00,1.00)   3.41s × (1.00,1.00)   -4.05% (p=0.000 n=10+10)
```