### PR TITLE
Change Matrix definition to support transposes. Add Transpose type in…

### DIFF
--- a/mat64/dense.go
+++ b/mat64/dense.go
@@ -145,6 +145,11 @@ func (m *Dense) Dims() (r, c int) { return m.mat.Rows, m.mat.Cols }
 // Caps returns the number of rows and columns in the backing matrix.
 func (m *Dense) Caps() (r, c int) { return m.capRows, m.capCols }
 
+// T performs an implicit transpose by returning the receiver inside a Transpose.
+func (m *Dense) T() Matrix {
+	return Transpose{m}
+}
+
 // Col copies the elements in the jth column of the matrix into the slice dst.
 // If the provided slice is nil, a new slice is first allocated.
 //

--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -22,6 +22,59 @@ type Matrix interface {
 	// At returns the value of a matrix element at (r, c). It will panic if r or c are
 	// out of bounds for the matrix.
 	At(r, c int) float64
+
+	// T returns the transpose of the Matrix. Whether T returns a copy of the
+	// underlying data is implementation dependent.
+	// This method may be implemented using the Transpose type, which
+	// provides an implicit matrix transpose.
+	T() Matrix
+}
+
+var (
+	_ Matrix       = Transpose{}
+	_ Untransposer = Transpose{}
+)
+
+// Transpose is a type for performing an implicit matrix transpose. It implements
+// the Matrix interface, returning values from the transpose of the matrix within.
+type Transpose struct {
+	Matrix Matrix
+}
+
+// At returns the value of the element at row i and column j of the transposed
+// matrix, that is, row j and column i of the Matrix field.
+func (t Transpose) At(i, j int) float64 {
+	return t.Matrix.At(j, i)
+}
+
+// Dims returns the dimensions of the transposed matrix. The number of rows returned
+// is the number of columns in the Matrix field, and the number of columns is
+// the number of rows in the Matrix field.
+func (t Transpose) Dims() (r, c int) {
+	c, r = t.Matrix.Dims()
+	return r, c
+}
+
+// T performs an implicit transpose by returning the Matrix field.
+func (t Transpose) T() Matrix {
+	return t.Matrix
+}
+
+// Untranspose returns the Matrix field.
+func (t Transpose) Untranspose() Matrix {
+	return t.Matrix
+}
+
+// Untransposer is a type that can undo an implicit transpose.
+type Untransposer interface {
+	// Note: This interface is needed to unify all of the Transpose types. In
+	// the mat64 methods, we need to test if the Matrix has been implicitly
+	// transposed. If this is checked by testing for the specific Transpose type
+	// then the behavior will be different if the user uses T() or TTri() for a
+	// triangular matrix.
+
+	// Untranspose returns the underlying Matrix stored for the implicit transpose.
+	Untranspose() Matrix
 }
 
 // Mutable is a matrix interface type that allows elements to be altered.
@@ -147,12 +200,6 @@ type Normer interface {
 // into the receiver.
 type TransposeCopier interface {
 	TCopy(a Matrix)
-}
-
-// A Transposer can create a transposed view matrix from the matrix represented by the receiver.
-// Changes made to the returned Matrix may be reflected in the original.
-type Transposer interface {
-	T() Matrix
 }
 
 // A Deter can return the determinant of the represented matrix.

--- a/mat64/mul_test.go
+++ b/mat64/mul_test.go
@@ -228,6 +228,10 @@ func (m *basicMatrix) Dims() (r, c int) {
 	return (*Dense)(m).Dims()
 }
 
+func (m *basicMatrix) T() Matrix {
+	return Transpose{m}
+}
+
 type basicVectorer Dense
 
 func (m *basicVectorer) At(r, c int) float64 {
@@ -236,6 +240,10 @@ func (m *basicVectorer) At(r, c int) float64 {
 
 func (m *basicVectorer) Dims() (r, c int) {
 	return (*Dense)(m).Dims()
+}
+
+func (m *basicVectorer) T() Matrix {
+	return Transpose{m}
 }
 
 func (m *basicVectorer) Row(row []float64, r int) []float64 {

--- a/mat64/symmetric.go
+++ b/mat64/symmetric.go
@@ -59,6 +59,12 @@ func (s *SymDense) Dims() (r, c int) {
 	return s.mat.N, s.mat.N
 }
 
+// T implements the Matrix interface. Symmetric matrices, by definition, are
+// equal to their transpose, and this is a no-op.
+func (s *SymDense) T() Matrix {
+	return s
+}
+
 func (s *SymDense) Symmetric() int {
 	return s.mat.N
 }

--- a/mat64/vector.go
+++ b/mat64/vector.go
@@ -94,6 +94,11 @@ func (v *Vector) Len() int {
 	return v.n
 }
 
+// T performs an implicit transpose by returning the receiver inside a Transpose.
+func (v *Vector) T() Matrix {
+	return Transpose{v}
+}
+
 func (v *Vector) Reset() {
 	v.mat.Data = v.mat.Data[:0]
 	v.mat.Inc = 0


### PR DESCRIPTION
… support.

There is a need to support matrix transposes, for example the ability to perform A^T * B in addition to A * B. One way to support this is to add input booleans specifying if the matrix is transposed, as is done now in MulTrans. This does not scale well for many arguments and functions. This change adds a T() method to Matrix to support implicit transposing of matrices. This allows user to call, for example, Mul(A.T(), B) to perform A^T * B.

Please see the discussion in 123 for more information.

Changes to actual methods in order to efficiently support this new method type will come in future commits.

Fixes issue #123.