### PR TITLE
mat64: use guaranteed zero values in test matrix

### DIFF
--- a/mat64/list_test.go
+++ b/mat64/list_test.go
@@ -376,8 +376,11 @@ func testTwoInput(c *check.C,
 	types := []Matrix{
 		&Dense{},
 		&SymDense{},
+		NewSymDense(0, nil),
+		&TriDense{},
 		NewTriDense(0, true, nil),
 		NewTriDense(0, false, nil),
+		&Vector{},
 		NewVector(0, nil),
 		strideVec,
 		&basicMatrix{},
@@ -386,6 +389,9 @@ func testTwoInput(c *check.C,
 		&basicTriangular{},
 
 		Transpose{&Dense{}},
+		Transpose{&SymDense{}},         // Check for transpose even on
+		Transpose{NewSymDense(0, nil)}, // types where it makes no sense.
+		Transpose{&TriDense{}},
 		Transpose{NewTriDense(0, true, nil)},
 		TransposeTri{NewTriDense(0, true, nil)},
 		Transpose{NewTriDense(0, false, nil)},


### PR DESCRIPTION
New functions may at some stage perform operations that make a returned Matrix not actually a zero value. We say we allow zero values, so make sure these will always be tested.

Mentioned in CopySym panic issue comment.

@btracey Please take a look.