### PR TITLE
mat64: fix matrix formatting support

### DIFF
--- a/mat64/format_example_test.go
+++ b/mat64/format_example_test.go
@@ -1,0 +1,99 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mat64_test
+
+import (
+	"fmt"
+
+	"github.com/gonum/matrix/mat64"
+)
+
+func Example_Formatted() {
+	a := mat64.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
+
+	// Create a matrix formatting value with a prefix ...
+	fa := mat64.Formatted(a, mat64.Prefix("    "))
+
+	// and then print with and without zero value elements.
+	fmt.Printf("with all values:\na = %v\n\n", fa)
+	fmt.Printf("with only non-zero values:\na = % v\n\n", fa)
+
+	// Modify the matrix...
+	a.Set(0, 2, 0)
+
+	// and print it without zero value elements.
+	fmt.Printf("after modification with only non-zero values:\na = % v\n\n", fa)
+
+	// Output:
+	// with all values:
+	// a = ⎡1  2  3⎤
+	//     ⎢0  4  5⎥
+	//     ⎣0  0  6⎦
+
+	// with only non-zero values:
+	// a = ⎡1  2  3⎤
+	//     ⎢.  4  5⎥
+	//     ⎣.  .  6⎦
+
+	// after modification with only non-zero values:
+	// a = ⎡1  2  .⎤
+	//     ⎢.  4  5⎥
+	//     ⎣.  .  6⎦
+}
+
+func Example_Excerpt() {
+	// Excerpt allows diagnostic display of very large
+	// matrices and vectors.
+
+	// The big matrix is too large to properly print...
+	big := mat64.NewDense(100, 100, nil)
+	for i := 0; i < 100; i++ {
+		big.Set(i, i, 1)
+	}
+
+	// so only print corner excerpts of the matrix.
+	fmt.Printf("excerpt big identity matrix: %v\n\n",
+		mat64.Formatted(big, mat64.Prefix(" "), mat64.Excerpt(3)))
+
+	// The long vector is also too large, ...
+	long := mat64.NewVector(100, nil)
+	for i := 0; i < 100; i++ {
+		long.SetVec(i, float64(i))
+	}
+
+	// ... so print end excerpts of the vector,
+	fmt.Printf("excerpt long column vector: %v\n\n",
+		mat64.Formatted(long, mat64.Prefix(" "), mat64.Excerpt(3)))
+	// or its transpose.
+	fmt.Printf("excerpt long row vector: %v\n",
+		mat64.Formatted(long.T(), mat64.Prefix(" "), mat64.Excerpt(3)))
+
+	// Output:
+	// excerpt big identity matrix: Dims(100, 100)
+	//  ⎡1  0  0  ...  ...  0  0  0⎤
+	//  ⎢0  1  0            0  0  0⎥
+	//  ⎢0  0  1            0  0  0⎥
+	//  .
+	//  .
+	//  .
+	//  ⎢0  0  0            1  0  0⎥
+	//  ⎢0  0  0            0  1  0⎥
+	//  ⎣0  0  0  ...  ...  0  0  1⎦
+	//
+	// excerpt long column vector: Dims(100, 1)
+	//  ⎡ 0⎤
+	//  ⎢ 1⎥
+	//  ⎢ 2⎥
+	//  .
+	//  .
+	//  .
+	//  ⎢97⎥
+	//  ⎢98⎥
+	//  ⎣99⎦
+	//
+	// excerpt long row vector: Dims(1, 100)
+	//  [ 0   1   2  ...  ...  97  98  99]
+
+}

--- a/mat64/format_test.go
+++ b/mat64/format_test.go
@@ -11,19 +11,6 @@ import (
 	"gopkg.in/check.v1"
 )
 
-type fm struct {
-	Matrix
-	margin int
-}
-
-func (m fm) Format(fs fmt.State, c rune) {
-	if c == 'v' && fs.Flag('#') {
-		fmt.Fprintf(fs, "%#v", m.Matrix)
-		return
-	}
-	Format(m.Matrix, m.margin, '.', fs, c)
-}
-
 func (s *S) TestFormat(c *check.C) {
 	type rp struct {
 		format string
@@ -31,102 +18,110 @@ func (s *S) TestFormat(c *check.C) {
 	}
 	sqrt := func(_, _ int, v float64) float64 { return math.Sqrt(v) }
 	for i, test := range []struct {
-		m   fm
+		m   fmt.Formatter
 		rep []rp
 	}{
 		// Dense matrix representation
 		{
-			fm{Matrix: NewDense(3, 3, []float64{0, 0, 0, 0, 0, 0, 0, 0, 0})},
+			Formatted(NewDense(3, 3, []float64{0, 0, 0, 0, 0, 0, 0, 0, 0})),
 			[]rp{
 				{"%v", "⎡0  0  0⎤\n⎢0  0  0⎥\n⎣0  0  0⎦"},
-				{"%#f", "⎡.  .  .⎤\n⎢.  .  .⎥\n⎣.  .  .⎦"},
+				{"% f", "⎡.  .  .⎤\n⎢.  .  .⎥\n⎣.  .  .⎦"},
 				{"%#v", "&mat64.Dense{mat:blas64.General{Rows:3, Cols:3, Stride:3, Data:[]float64{0, 0, 0, 0, 0, 0, 0, 0, 0}}, capRows:3, capCols:3}"},
 				{"%s", "%!s(*mat64.Dense=Dims(3, 3))"},
 			},
 		},
 		{
-			fm{Matrix: NewDense(3, 3, []float64{1, 1, 1, 1, 1, 1, 1, 1, 1})},
+			Formatted(NewDense(3, 3, []float64{1, 1, 1, 1, 1, 1, 1, 1, 1})),
 			[]rp{
 				{"%v", "⎡1  1  1⎤\n⎢1  1  1⎥\n⎣1  1  1⎦"},
-				{"%#f", "⎡1  1  1⎤\n⎢1  1  1⎥\n⎣1  1  1⎦"},
+				{"% f", "⎡1  1  1⎤\n⎢1  1  1⎥\n⎣1  1  1⎦"},
 				{"%#v", "&mat64.Dense{mat:blas64.General{Rows:3, Cols:3, Stride:3, Data:[]float64{1, 1, 1, 1, 1, 1, 1, 1, 1}}, capRows:3, capCols:3}"},
 			},
 		},
 		{
-			fm{Matrix: NewDense(3, 3, []float64{1, 0, 0, 0, 1, 0, 0, 0, 1})},
+			Formatted(NewDense(3, 3, []float64{1, 1, 1, 1, 1, 1, 1, 1, 1}), Prefix("\t")),
+			[]rp{
+				{"%v", "⎡1  1  1⎤\n\t⎢1  1  1⎥\n\t⎣1  1  1⎦"},
+				{"% f", "⎡1  1  1⎤\n\t⎢1  1  1⎥\n\t⎣1  1  1⎦"},
+				{"%#v", "&mat64.Dense{mat:blas64.General{Rows:3, Cols:3, Stride:3, Data:[]float64{1, 1, 1, 1, 1, 1, 1, 1, 1}}, capRows:3, capCols:3}"},
+			},
+		},
+		{
+			Formatted(NewDense(3, 3, []float64{1, 0, 0, 0, 1, 0, 0, 0, 1})),
 			[]rp{
 				{"%v", "⎡1  0  0⎤\n⎢0  1  0⎥\n⎣0  0  1⎦"},
-				{"%#f", "⎡1  .  .⎤\n⎢.  1  .⎥\n⎣.  .  1⎦"},
+				{"% f", "⎡1  .  .⎤\n⎢.  1  .⎥\n⎣.  .  1⎦"},
 				{"%#v", "&mat64.Dense{mat:blas64.General{Rows:3, Cols:3, Stride:3, Data:[]float64{1, 0, 0, 0, 1, 0, 0, 0, 1}}, capRows:3, capCols:3}"},
 			},
 		},
 		{
-			fm{Matrix: NewDense(2, 3, []float64{1, 2, 3, 4, 5, 6})},
+			Formatted(NewDense(2, 3, []float64{1, 2, 3, 4, 5, 6})),
 			[]rp{
 				{"%v", "⎡1  2  3⎤\n⎣4  5  6⎦"},
-				{"%#f", "⎡1  2  3⎤\n⎣4  5  6⎦"},
+				{"% f", "⎡1  2  3⎤\n⎣4  5  6⎦"},
 				{"%#v", "&mat64.Dense{mat:blas64.General{Rows:2, Cols:3, Stride:3, Data:[]float64{1, 2, 3, 4, 5, 6}}, capRows:2, capCols:3}"},
 			},
 		},
 		{
-			fm{Matrix: NewDense(3, 2, []float64{1, 2, 3, 4, 5, 6})},
+			Formatted(NewDense(3, 2, []float64{1, 2, 3, 4, 5, 6})),
 			[]rp{
 				{"%v", "⎡1  2⎤\n⎢3  4⎥\n⎣5  6⎦"},
-				{"%#f", "⎡1  2⎤\n⎢3  4⎥\n⎣5  6⎦"},
+				{"% f", "⎡1  2⎤\n⎢3  4⎥\n⎣5  6⎦"},
 				{"%#v", "&mat64.Dense{mat:blas64.General{Rows:3, Cols:2, Stride:2, Data:[]float64{1, 2, 3, 4, 5, 6}}, capRows:3, capCols:2}"},
 			},
 		},
 		{
-			func() fm {
+			func() fmt.Formatter {
 				m := NewDense(2, 3, []float64{0, 1, 2, 3, 4, 5})
 				m.Apply(sqrt, m)
-				return fm{Matrix: m}
+				return Formatted(m)
 			}(),
 			[]rp{
 				{"%v", "⎡                 0                   1  1.4142135623730951⎤\n⎣1.7320508075688772                   2    2.23606797749979⎦"},
 				{"%.2f", "⎡0.00  1.00  1.41⎤\n⎣1.73  2.00  2.24⎦"},
-				{"%#f", "⎡                 .                   1  1.4142135623730951⎤\n⎣1.7320508075688772                   2    2.23606797749979⎦"},
+				{"% f", "⎡                 .                   1  1.4142135623730951⎤\n⎣1.7320508075688772                   2    2.23606797749979⎦"},
 				{"%#v", "&mat64.Dense{mat:blas64.General{Rows:2, Cols:3, Stride:3, Data:[]float64{0, 1, 1.4142135623730951, 1.7320508075688772, 2, 2.23606797749979}}, capRows:2, capCols:3}"},
 			},
 		},
 		{
-			func() fm {
+			func() fmt.Formatter {
 				m := NewDense(3, 2, []float64{0, 1, 2, 3, 4, 5})
 				m.Apply(sqrt, m)
-				return fm{Matrix: m}
+				return Formatted(m)
 			}(),
 			[]rp{
 				{"%v", "⎡                 0                   1⎤\n⎢1.4142135623730951  1.7320508075688772⎥\n⎣                 2    2.23606797749979⎦"},
 				{"%.2f", "⎡0.00  1.00⎤\n⎢1.41  1.73⎥\n⎣2.00  2.24⎦"},
-				{"%#f", "⎡                 .                   1⎤\n⎢1.4142135623730951  1.7320508075688772⎥\n⎣                 2    2.23606797749979⎦"},
+				{"% f", "⎡                 .                   1⎤\n⎢1.4142135623730951  1.7320508075688772⎥\n⎣                 2    2.23606797749979⎦"},
 				{"%#v", "&mat64.Dense{mat:blas64.General{Rows:3, Cols:2, Stride:2, Data:[]float64{0, 1, 1.4142135623730951, 1.7320508075688772, 2, 2.23606797749979}}, capRows:3, capCols:2}"},
 			},
 		},
 		{
-			func() fm {
+			func() fmt.Formatter {
 				m := NewDense(1, 10, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
-				return fm{Matrix: m, margin: 3}
+				return Formatted(m, Excerpt(3))
 			}(),
 			[]rp{
 				{"%v", "Dims(1, 10)\n[ 1   2   3  ...  ...   8   9  10]"},
 			},
 		},
 		{
-			func() fm {
+			func() fmt.Formatter {
 				m := NewDense(10, 1, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
-				return fm{Matrix: m, margin: 3}
+				return Formatted(m, Excerpt(3))
 			}(),
 			[]rp{
 				{"%v", "Dims(10, 1)\n⎡ 1⎤\n⎢ 2⎥\n⎢ 3⎥\n .\n .\n .\n⎢ 8⎥\n⎢ 9⎥\n⎣10⎦"},
 			},
 		},
 		{
-			func() fm {
+			func() fmt.Formatter {
 				m := NewDense(10, 10, nil)
 				for i := 0; i < 10; i++ {
 					m.Set(i, i, 1)
 				}
-				return fm{Matrix: m, margin: 3}
+				return Formatted(m, Excerpt(3))
 			}(),
 			[]rp{
 				{"%v", "Dims(10, 10)\n⎡1  0  0  ...  ...  0  0  0⎤\n⎢0  1  0            0  0  0⎥\n⎢0  0  1            0  0  0⎥\n .\n .\n .\n⎢0  0  0            1  0  0⎥\n⎢0  0  0            0  1  0⎥\n⎣0  0  0  ...  ...  0  0  1⎦"},


### PR DESCRIPTION
After discussion at https://groups.google.com/d/topic/gonum-dev/0J9-itOjz08/discussion

This is still fiddling around the edges, but I think the loss of overloading the '#' modifier is a positive step.