### PR TITLE
mat64: add Copy to TriDense and drop Ler/Uer interfaces and methods

### DIFF
--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -841,69 +841,6 @@ func (m *Dense) iterativePow(a Matrix, n int) {
 	}
 }
 
-func (s *S) TestLU(c *check.C) {
-	for i := 0; i < 100; i++ {
-		size := rand.Intn(100)
-		r, err := randDense(size, rand.Float64(), rand.NormFloat64)
-		if size == 0 {
-			c.Check(err, check.Equals, ErrZeroLength)
-			continue
-		}
-		c.Assert(err, check.Equals, nil)
-
-		var (
-			u, l Dense
-			rc   *Dense
-		)
-
-		u.U(r)
-		l.L(r)
-		for m := 0; m < size; m++ {
-			for n := 0; n < size; n++ {
-				switch {
-				case m < n: // Upper triangular matrix.
-					c.Check(u.At(m, n), check.Equals, r.At(m, n), check.Commentf("Test #%d At(%d, %d)", i, m, n))
-				case m == n: // Diagonal matrix.
-					c.Check(u.At(m, n), check.Equals, l.At(m, n), check.Commentf("Test #%d At(%d, %d)", i, m, n))
-					c.Check(u.At(m, n), check.Equals, r.At(m, n), check.Commentf("Test #%d At(%d, %d)", i, m, n))
-				case m < n: // Lower triangular matrix.
-					c.Check(l.At(m, n), check.Equals, r.At(m, n), check.Commentf("Test #%d At(%d, %d)", i, m, n))
-				}
-			}
-		}
-
-		rc = DenseCopyOf(r)
-		rc.U(rc)
-		for m := 0; m < size; m++ {
-			for n := 0; n < size; n++ {
-				switch {
-				case m < n: // Upper triangular matrix.
-					c.Check(rc.At(m, n), check.Equals, r.At(m, n), check.Commentf("Test #%d At(%d, %d)", i, m, n))
-				case m == n: // Diagonal matrix.
-					c.Check(rc.At(m, n), check.Equals, r.At(m, n), check.Commentf("Test #%d At(%d, %d)", i, m, n))
-				case m > n: // Lower triangular matrix.
-					c.Check(rc.At(m, n), check.Equals, 0., check.Commentf("Test #%d At(%d, %d)", i, m, n))
-				}
-			}
-		}
-
-		rc = DenseCopyOf(r)
-		rc.L(rc)
-		for m := 0; m < size; m++ {
-			for n := 0; n < size; n++ {
-				switch {
-				case m < n: // Upper triangular matrix.
-					c.Check(rc.At(m, n), check.Equals, 0., check.Commentf("Test #%d At(%d, %d)", i, m, n))
-				case m == n: // Diagonal matrix.
-					c.Check(rc.At(m, n), check.Equals, r.At(m, n), check.Commentf("Test #%d At(%d, %d)", i, m, n))
-				case m > n: // Lower triangular matrix.
-					c.Check(rc.At(m, n), check.Equals, r.At(m, n), check.Commentf("Test #%d At(%d, %d)", i, m, n))
-				}
-			}
-		}
-	}
-}
-
 func (s *S) TestTranspose(c *check.C) {
 	for i, test := range []struct {
 		a, t [][]float64

--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -322,18 +322,6 @@ type Tracer interface {
 	Trace() float64
 }
 
-// A Uer can return the upper triangular matrix of the matrix represented by a, placing the result
-// in the receiver. If the concrete value of a is the receiver, the lower residue is zeroed in place.
-type Uer interface {
-	U(a Matrix)
-}
-
-// An Ler can return the lower triangular matrix of the matrix represented by a, placing the result
-// in the receiver. If the concrete value of a is the receiver, the upper residue is zeroed in place.
-type Ler interface {
-	L(a Matrix)
-}
-
 // A BandWidther represents a banded matrix and can return the left and right half-bandwidths, k1 and
 // k2.
 type BandWidther interface {

--- a/mat64/triangular_test.go
+++ b/mat64/triangular_test.go
@@ -1,6 +1,8 @@
 package mat64
 
 import (
+	"math/rand"
+
 	"github.com/gonum/blas"
 	"github.com/gonum/blas/blas64"
 	"gopkg.in/check.v1"
@@ -70,4 +72,70 @@ func (s *S) TestTriAtSet(c *check.C) {
 	c.Check(t.At(1, 2), check.Equals, 6.0)
 	t.SetTri(1, 2, 15)
 	c.Check(t.At(1, 2), check.Equals, 15.0)
+}
+
+func (s *S) TestTriDenseCopy(c *check.C) {
+	for i := 0; i < 100; i++ {
+		size := rand.Intn(100)
+		r, err := randDense(size, 0.9, rand.NormFloat64)
+		if size == 0 {
+			c.Check(err, check.Equals, ErrZeroLength)
+			continue
+		}
+		c.Assert(err, check.Equals, nil)
+
+		u := NewTriDense(size, true, nil)
+		l := NewTriDense(size, false, nil)
+
+		u.Copy(r)
+		l.Copy(r)
+		for m := 0; m < size; m++ {
+			for n := 0; n < size; n++ {
+				e := r.At(m, n)
+				switch {
+				case m < n: // Upper triangular matrix.
+					c.Check(u.At(m, n), check.Equals, e, check.Commentf("Test #%d At(%d, %d)", i, m, n))
+				case m == n: // Diagonal matrix.
+					c.Check(u.At(m, n), check.Equals, e, check.Commentf("Test #%d At(%d, %d)", i, m, n))
+					c.Check(l.At(m, n), check.Equals, e, check.Commentf("Test #%d At(%d, %d)", i, m, n))
+				case m < n: // Lower triangular matrix.
+					c.Check(l.At(m, n), check.Equals, e, check.Commentf("Test #%d At(%d, %d)", i, m, n))
+				}
+			}
+		}
+
+		u.Copy((*basicVectorer)(r))
+		l.Copy((*basicVectorer)(r))
+		for m := 0; m < size; m++ {
+			for n := 0; n < size; n++ {
+				e := r.At(m, n)
+				switch {
+				case m < n: // Upper triangular matrix.
+					c.Check(u.At(m, n), check.Equals, e, check.Commentf("Test #%d At(%d, %d)", i, m, n))
+				case m == n: // Diagonal matrix.
+					c.Check(u.At(m, n), check.Equals, e, check.Commentf("Test #%d At(%d, %d)", i, m, n))
+					c.Check(l.At(m, n), check.Equals, e, check.Commentf("Test #%d At(%d, %d)", i, m, n))
+				case m < n: // Lower triangular matrix.
+					c.Check(l.At(m, n), check.Equals, e, check.Commentf("Test #%d At(%d, %d)", i, m, n))
+				}
+			}
+		}
+
+		u.Copy((*basicMatrix)(r))
+		l.Copy((*basicMatrix)(r))
+		for m := 0; m < size; m++ {
+			for n := 0; n < size; n++ {
+				e := r.At(m, n)
+				switch {
+				case m < n: // Upper triangular matrix.
+					c.Check(u.At(m, n), check.Equals, e, check.Commentf("Test #%d At(%d, %d)", i, m, n))
+				case m == n: // Diagonal matrix.
+					c.Check(u.At(m, n), check.Equals, e, check.Commentf("Test #%d At(%d, %d)", i, m, n))
+					c.Check(l.At(m, n), check.Equals, e, check.Commentf("Test #%d At(%d, %d)", i, m, n))
+				case m < n: // Lower triangular matrix.
+					c.Check(l.At(m, n), check.Equals, e, check.Commentf("Test #%d At(%d, %d)", i, m, n))
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Depends #187.
Updates #138.

@btracey Please take a look.