### PR TITLE
mat64: drop TCopy method and associated interface

### DIFF
--- a/mat64/cholesky_test.go
+++ b/mat64/cholesky_test.go
@@ -112,13 +112,10 @@ func (s *S) TestCholesky(c *check.C) {
 		fc := DenseCopyOf(t.f)
 		c.Check(fc.Equals(t.want), check.Equals, true)
 
-		ft := &Dense{}
-		ft.TCopy(t.f)
-
 		if t.upper {
-			fc.Mul(ft, fc)
+			fc.Mul(t.f.T(), fc)
 		} else {
-			fc.Mul(fc, ft)
+			fc.Mul(fc, t.f.T())
 		}
 		c.Check(fc.EqualsApprox(t.a, 1e-12), check.Equals, true)
 

--- a/mat64/dense_arithmetic.go
+++ b/mat64/dense_arithmetic.go
@@ -406,7 +406,7 @@ func (m *Dense) Mul(a, b Matrix) {
 			if aTrans {
 				c := getWorkspace(ac, ar, false)
 				blas64.Symm(blas.Left, 1, bmat, amat, 0, c.mat)
-				m.TCopy(c)
+				strictCopy(m, c.T())
 				putWorkspace(c)
 				return
 			}
@@ -426,7 +426,7 @@ func (m *Dense) Mul(a, b Matrix) {
 					bT = blas.NoTrans
 				}
 				blas64.Trmm(blas.Left, bT, 1, bmat, c.mat)
-				m.TCopy(c)
+				strictCopy(m, c.T())
 				putWorkspace(c)
 				return
 			}
@@ -463,7 +463,7 @@ func (m *Dense) Mul(a, b Matrix) {
 			if bTrans {
 				c := getWorkspace(bc, br, false)
 				blas64.Symm(blas.Right, 1, amat, bmat, 0, c.mat)
-				m.TCopy(c)
+				strictCopy(m, c.T())
 				putWorkspace(c)
 				return
 			}
@@ -483,7 +483,7 @@ func (m *Dense) Mul(a, b Matrix) {
 					aT = blas.NoTrans
 				}
 				blas64.Trmm(blas.Right, aT, 1, amat, c.mat)
-				m.TCopy(c)
+				strictCopy(m, c.T())
 				putWorkspace(c)
 				return
 			}
@@ -586,6 +586,16 @@ func (m *Dense) Mul(a, b Matrix) {
 			}
 			m.mat.Data[r*m.mat.Stride+c] = v
 		}
+	}
+}
+
+// strictCopy copies a into m panicking if the shape of a and m differ.
+func strictCopy(m *Dense, a Matrix) {
+	r, c := m.Copy(a)
+	if r != m.mat.Rows || c != m.mat.Cols {
+		// Panic with a string since this
+		// is not a user-facing panic.
+		panic(ErrShape.string)
 	}
 }
 

--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -841,7 +841,7 @@ func (m *Dense) iterativePow(a Matrix, n int) {
 	}
 }
 
-func (s *S) TestTranspose(c *check.C) {
+func (s *S) TestCloneT(c *check.C) {
 	for i, test := range []struct {
 		a, t [][]float64
 	}{
@@ -871,19 +871,67 @@ func (s *S) TestTranspose(c *check.C) {
 
 		var r, rr Dense
 
-		r.TCopy(a)
+		r.Clone(a.T())
 		c.Check(r.Equals(t), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
 
-		rr.TCopy(&r)
-		c.Check(rr.Equals(a), check.Equals, true, check.Commentf("Test %d: %v transpose = I", i, test.a, test.t))
+		rr.Clone(r.T())
+		c.Check(rr.Equals(a), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
 
 		zero(r.mat.Data)
-		r.TCopy(a)
+		r.Clone(a.T())
 		c.Check(r.Equals(t), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
 
 		zero(rr.mat.Data)
-		rr.TCopy(&r)
-		c.Check(rr.Equals(a), check.Equals, true, check.Commentf("Test %d: %v transpose = I", i, test.a, test.t))
+		rr.Clone(r.T())
+		c.Check(rr.Equals(a), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
+	}
+}
+
+func (s *S) TestCopyT(c *check.C) {
+	for i, test := range []struct {
+		a, t [][]float64
+	}{
+		{
+			[][]float64{{0, 0, 0}, {0, 0, 0}, {0, 0, 0}},
+			[][]float64{{0, 0, 0}, {0, 0, 0}, {0, 0, 0}},
+		},
+		{
+			[][]float64{{1, 1, 1}, {1, 1, 1}, {1, 1, 1}},
+			[][]float64{{1, 1, 1}, {1, 1, 1}, {1, 1, 1}},
+		},
+		{
+			[][]float64{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}},
+			[][]float64{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}},
+		},
+		{
+			[][]float64{{-1, 0, 0}, {0, -1, 0}, {0, 0, -1}},
+			[][]float64{{-1, 0, 0}, {0, -1, 0}, {0, 0, -1}},
+		},
+		{
+			[][]float64{{1, 2, 3}, {4, 5, 6}},
+			[][]float64{{1, 4}, {2, 5}, {3, 6}},
+		},
+	} {
+		a := NewDense(flatten(test.a))
+		t := NewDense(flatten(test.t))
+
+		ar, ac := a.Dims()
+		r := NewDense(ac, ar, nil)
+		rr := NewDense(ar, ac, nil)
+
+		r.Copy(a.T())
+		c.Check(r.Equals(t), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
+
+		rr.Copy(r.T())
+		c.Check(rr.Equals(a), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
+
+		zero(r.mat.Data)
+		r.Copy(a.T())
+		c.Check(r.Equals(t), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
+
+		zero(rr.mat.Data)
+		rr.Copy(r.T())
+		c.Check(rr.Equals(a), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
 	}
 }
 

--- a/mat64/lq_test.go
+++ b/mat64/lq_test.go
@@ -71,10 +71,7 @@ func (s *S) TestLQD(c *check.C) {
 	} {
 		a := NewDense(flatten(test.a))
 
-		at := new(Dense)
-		at.TCopy(a)
-
-		lq := LQ(DenseCopyOf(at))
+		lq := LQ(DenseCopyOf(a.T()))
 
 		rows, cols := a.Dims()
 
@@ -87,8 +84,7 @@ func (s *S) TestLQD(c *check.C) {
 
 		lt := NewDense(rows, cols, nil)
 		ltview := lt.View(0, 0, cols, cols).(*Dense)
-		ltview.TCopy(l)
-		lq.applyQTo(lt, true)
+		lq.applyQTo(l.T(), true)
 
 		c.Check(isOrthogonal(Q), check.Equals, true, check.Commentf("Test %v: Q not orthogonal", test.name))
 		c.Check(a.EqualsApprox(lt, 1e-13), check.Equals, true, check.Commentf("Test %v: Q*R != A", test.name))
@@ -105,7 +101,7 @@ func (s *S) TestLQD(c *check.C) {
 		x := lq.Solve(b)
 
 		var bProj Dense
-		bProj.Mul(at, x)
+		bProj.Mul(a.T(), x)
 
 		c.Check(bProj.EqualsApprox(b, 1e-13), check.Equals, true, check.Commentf("Test %v: A*X != B", test.name))
 

--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -157,6 +157,8 @@ type Reseter interface {
 // A Copier can make a copy of elements of a into the receiver. The submatrix copied
 // starts at row and column 0 and has dimensions equal to the minimum dimensions of
 // the two matrices. The number of row and columns copied is returned.
+// Note that the behavior of Copy from a Matrix with backing data that aliases the
+// receiver is undefined.
 type Copier interface {
 	Copy(a Matrix) (r, c int)
 }
@@ -192,12 +194,6 @@ type Grower interface {
 // Norm will panic with ErrNormOrder if an illegal norm order is specified.
 type Normer interface {
 	Norm(o float64) float64
-}
-
-// A TransposeCopier can make a copy of the transpose the matrix represented by a, placing the elements
-// into the receiver.
-type TransposeCopier interface {
-	TCopy(a Matrix)
 }
 
 // A Deter can return the determinant of the represented matrix.

--- a/mat64/svd.go
+++ b/mat64/svd.go
@@ -34,7 +34,7 @@ func SVD(a *Dense, epsilon, small float64, wantu, wantv bool) SVDFactors {
 
 	trans := false
 	if m < n {
-		a.TCopy(a)
+		a.Clone(a.T())
 		m, n = n, m
 		wantu, wantv = wantv, wantu
 		trans = true

--- a/mat64/svd_test.go
+++ b/mat64/svd_test.go
@@ -192,11 +192,9 @@ func (s *S) TestSVD(c *check.C) {
 		if t.wantu && t.wantv {
 			c.Assert(svd.U, check.NotNil)
 			c.Assert(svd.V, check.NotNil)
-			vt := &Dense{}
-			vt.TCopy(svd.V)
 			var tmp, got Dense
 			tmp.Mul(svd.U, s)
-			got.Mul(&tmp, vt)
+			got.Mul(&tmp, svd.V.T())
 			c.Check(got.EqualsApprox(t.a, 1e-12), check.Equals, true)
 		}
 	}


### PR DESCRIPTION
Depending on the desired behaviour, m.TCopy(a) can be replaced by m.Copy(a.T()) or m.Clone(a.T()). This significantly clarifies the intention over the previous situation; TCopy's semantics were weird - it did not obey the normal copy semantics (it allocated when the receiver was zero) and did not obey normal clone semantics (it did not destroy the surrounding matrix).

Updates #138.

@btracey  Please take a look.

TODO(kortschak) add "Fixes # 194." before merge.