### PR TITLE
mat64: change wording of comment to avoid overloaded English

### DIFF
--- a/mat64/cholesky_example_test.go
+++ b/mat64/cholesky_example_test.go
@@ -11,13 +11,15 @@ import (
 )
 
 func ExampleCholesky() {
-	// Construct a new SymDense. Only the upper triangular data elements are used
-	// so the lower triangular elements could alternately be zero.
+	// Construct a new SymDense. Only the upper triangular data
+	// elements are used, so the lower triangular elements may
+	// be set zero without altering the semantics.
 	a := mat64.NewSymDense(4, []float64{
 		108, -21, -9, -96,
 		-21, 7, 5, 15,
 		-9, 5, 61, 25,
-		-96, 15, 25, 142})
+		-96, 15, 25, 142,
+	})
 
 	fmt.Printf("a = %0.4v\n", mat64.Formatted(a, mat64.Prefix("    ")))
 

--- a/mat64/doc.go
+++ b/mat64/doc.go
@@ -20,7 +20,7 @@
 // Many operations are performed by calling into the gonum/blas/blas64 and
 // gonum/lapack/lapack64 packages which implement BLAS and LAPACK routines
 // respectively. By default, blas64 and lapack64 use native Go implementations
-// of the routines. Alternately, it is possible to use c-based libraries for
+// of the routines. Alternatively, it is possible to use c-based libraries for
 // the BLAS routines and/or the LAPACK routines with the respective cgo packages
 // and Use routines. The Go implementation of LAPACK itself makes calls to blas64,
 // so if a cgo BLAS implementation is used, the lapack64 calls will be partially


### PR DESCRIPTION
The word "alternate" in non-North American English means to change from one to a another (*v*.) successively or the other that is alternated to, i.e. every second one (*v*.). In North American English it is increasingly being used to signify "alternative", however it retains the original meaning. So avoid the term.

In the Cholesky comment it could be interpreted to mean that every second element is zero. Foolishly, true, but let's not allow that.

@btracey Please take a look.