### PR TITLE
Loosen solve tolerance.

### DIFF
--- a/mat64/solve_test.go
+++ b/mat64/solve_test.go
@@ -246,7 +246,7 @@ func (s *S) TestSolve(c *check.C) {
 	denseComparison := func(receiver, a, b *Dense) {
 		receiver.Solve(a, b)
 	}
-	testTwoInput(c, "Solve", &Dense{}, method, denseComparison, legalTypesAll, legalSizeSolve, 1e-12)
+	testTwoInput(c, "Solve", &Dense{}, method, denseComparison, legalTypesAll, legalSizeSolve, 1e-7)
 }
 
 func (s *S) TestSolveVec(c *check.C) {


### PR DESCRIPTION
The problem is that randomly generated matrices can be very ill-conditioned. Loosen the solve tolerance until we have a better way of generating random matrices. An example of generating well-conditioned matrices is in the tests for Dgetri