### PR TITLE
mat64: remove gocheck dependency

### DIFF
--- a/mat64/cholesky_test.go
+++ b/mat64/cholesky_test.go
@@ -8,11 +8,9 @@ import (
 	"math"
 	"math/rand"
 	"testing"
-
-	"gopkg.in/check.v1"
 )
 
-func (s *S) TestCholesky(c *check.C) {
+func TestCholesky(t *testing.T) {
 	for _, test := range []struct {
 		a *SymDense
 
@@ -44,14 +42,14 @@ func (s *S) TestCholesky(c *check.C) {
 		} {
 			ok := chol.Factorize(test.a)
 			if ok != test.posdef {
-				c.Errorf("unexpected return from Cholesky factorization: got: ok=%t want: ok=%t", ok, test.posdef)
+				t.Errorf("unexpected return from Cholesky factorization: got: ok=%t want: ok=%t", ok, test.posdef)
 			}
 			fc := DenseCopyOf(chol.chol)
 			if !Equal(fc, test.want) {
-				c.Error("incorrect Cholesky factorization")
+				t.Error("incorrect Cholesky factorization")
 			}
 			if math.Abs(test.cond-chol.cond) > 1e-13 {
-				c.Errorf("Condition number mismatch: Want %v, got %v", test.cond, chol.cond)
+				t.Errorf("Condition number mismatch: Want %v, got %v", test.cond, chol.cond)
 			}
 			var U TriDense
 			U.UFromCholesky(chol)
@@ -59,20 +57,20 @@ func (s *S) TestCholesky(c *check.C) {
 			var a Dense
 			a.Mul(U.TTri(), &U)
 			if !EqualApprox(&a, aCopy, 1e-14) {
-				c.Error("unexpected Cholesky factor product")
+				t.Error("unexpected Cholesky factor product")
 			}
 
 			var L TriDense
 			L.LFromCholesky(chol)
 			a.Mul(&L, L.TTri())
 			if !EqualApprox(&a, aCopy, 1e-14) {
-				c.Error("unexpected Cholesky factor product")
+				t.Error("unexpected Cholesky factor product")
 			}
 		}
 	}
 }
 
-func (s *S) TestCholeskySolve(c *check.C) {
+func TestCholeskySolve(t *testing.T) {
 	for _, test := range []struct {
 		a   *SymDense
 		b   *Dense
@@ -99,24 +97,24 @@ func (s *S) TestCholeskySolve(c *check.C) {
 		var chol Cholesky
 		ok := chol.Factorize(test.a)
 		if !ok {
-			c.Fatal("unexpected Cholesky factorization failure: not positive definite")
+			t.Fatal("unexpected Cholesky factorization failure: not positive definite")
 		}
 
 		var x Dense
 		x.SolveCholesky(&chol, test.b)
 		if !EqualApprox(&x, test.ans, 1e-12) {
-			c.Error("incorrect Cholesky solve solution")
+			t.Error("incorrect Cholesky solve solution")
 		}
 
 		var ans Dense
 		ans.Mul(test.a, &x)
 		if !EqualApprox(&ans, test.b, 1e-12) {
-			c.Error("incorrect Cholesky solve solution product")
+			t.Error("incorrect Cholesky solve solution product")
 		}
 	}
 }
 
-func (s *S) TestCholeskySolveVec(c *check.C) {
+func TestCholeskySolveVec(t *testing.T) {
 	for _, test := range []struct {
 		a   *SymDense
 		b   *Vector
@@ -143,19 +141,19 @@ func (s *S) TestCholeskySolveVec(c *check.C) {
 		var chol Cholesky
 		ok := chol.Factorize(test.a)
 		if !ok {
-			c.Fatal("unexpected Cholesky factorization failure: not positive definite")
+			t.Fatal("unexpected Cholesky factorization failure: not positive definite")
 		}
 
 		var x Vector
 		x.SolveCholeskyVec(&chol, test.b)
 		if !EqualApprox(&x, test.ans, 1e-12) {
-			c.Error("incorrect Cholesky solve solution")
+			t.Error("incorrect Cholesky solve solution")
 		}
 
 		var ans Vector
 		ans.MulVec(test.a, &x)
 		if !EqualApprox(&ans, test.b, 1e-12) {
-			c.Error("incorrect Cholesky solve solution product")
+			t.Error("incorrect Cholesky solve solution product")
 		}
 	}
 }

--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/gonum/blas/blas64"
 	"github.com/gonum/floats"
-	"gopkg.in/check.v1"
 )
 
 func asDense(d *Dense) Matrix {
@@ -33,7 +32,7 @@ func asBasicTriangular(t *TriDense) Triangular {
 	return (*basicTriangular)(t)
 }
 
-func (s *S) TestNewDense(c *check.C) {
+func TestNewDense(t *testing.T) {
 	for i, test := range []struct {
 		a          []float64
 		rows, cols int
@@ -152,30 +151,30 @@ func (s *S) TestNewDense(c *check.C) {
 		m := NewDense(test.rows, test.cols, test.a)
 		rows, cols := m.Dims()
 		if rows != test.rows {
-			c.Errorf("unexpected number of rows for test %d: got: %d want: %d", i, rows, test.rows)
+			t.Errorf("unexpected number of rows for test %d: got: %d want: %d", i, rows, test.rows)
 		}
 		if cols != test.cols {
-			c.Errorf("unexpected number of cols for test %d: got: %d want: %d", i, cols, test.cols)
+			t.Errorf("unexpected number of cols for test %d: got: %d want: %d", i, cols, test.cols)
 		}
 		if min := Min(m); min != test.min {
-			c.Errorf("unexpected min for test %d: got: %v want: %v", i, min, test.min)
+			t.Errorf("unexpected min for test %d: got: %v want: %v", i, min, test.min)
 		}
 		if max := Max(m); max != test.max {
-			c.Errorf("unexpected max for test %d: got: %v want: %v", i, max, test.max)
+			t.Errorf("unexpected max for test %d: got: %v want: %v", i, max, test.max)
 		}
 		if fro := Norm(m, 2); math.Abs(Norm(m, 2)-test.fro) > 1e-14 {
-			c.Errorf("unexpected Frobenius norm for test %d: got: %v want: %v", i, fro, test.fro)
+			t.Errorf("unexpected Frobenius norm for test %d: got: %v want: %v", i, fro, test.fro)
 		}
 		if !reflect.DeepEqual(m, test.mat) {
-			c.Errorf("unexpected matrix for test %d", i)
+			t.Errorf("unexpected matrix for test %d", i)
 		}
 		if !Equal(m, test.mat) {
-			c.Errorf("matrix does not equal expected matrix for test %d", i)
+			t.Errorf("matrix does not equal expected matrix for test %d", i)
 		}
 	}
 }
 
-func (s *S) TestAtSet(c *check.C) {
+func TestAtSet(t *testing.T) {
 	for test, af := range [][][]float64{
 		{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, // even
 		{{1, 2}, {4, 5}, {7, 8}},          // wide
@@ -186,13 +185,13 @@ func (s *S) TestAtSet(c *check.C) {
 		for i := 0; i < rows; i++ {
 			for j := 0; j < cols; j++ {
 				if m.At(i, j) != af[i][j] {
-					c.Errorf("unexpected value for At(%d, %d) for test %d: got: %v want: %v", m.At(i, j), af[i][j])
+					t.Errorf("unexpected value for At(%d, %d) for test %d: got: %v want: %v", m.At(i, j), af[i][j])
 				}
 
 				v := float64(i * j)
 				m.Set(i, j, v)
 				if m.At(i, j) != v {
-					c.Errorf("unexpected value for At(%d, %d) after Set(%[1]d, %d, %v) for test %d: got: %v want: %[3]v",
+					t.Errorf("unexpected value for At(%d, %d) after Set(%[1]d, %d, %v) for test %d: got: %v want: %[3]v",
 						i, j, v, test, m.At(i, j))
 				}
 			}
@@ -201,13 +200,13 @@ func (s *S) TestAtSet(c *check.C) {
 		for _, row := range []int{-1, rows, rows + 1} {
 			panicked, message := panics(func() { m.At(row, 0) })
 			if !panicked || message != ErrRowAccess.Error() {
-				c.Errorf("expected panic for invalid row access N=%d r=%d", rows, row)
+				t.Errorf("expected panic for invalid row access N=%d r=%d", rows, row)
 			}
 		}
 		for _, col := range []int{-1, cols, cols + 1} {
 			panicked, message := panics(func() { m.At(0, col) })
 			if !panicked || message != ErrColAccess.Error() {
-				c.Errorf("expected panic for invalid column access N=%d c=%d", cols, col)
+				t.Errorf("expected panic for invalid column access N=%d c=%d", cols, col)
 			}
 		}
 
@@ -215,19 +214,19 @@ func (s *S) TestAtSet(c *check.C) {
 		for _, row := range []int{-1, rows, rows + 1} {
 			panicked, message := panics(func() { m.Set(row, 0, 1.2) })
 			if !panicked || message != ErrRowAccess.Error() {
-				c.Errorf("expected panic for invalid row access N=%d r=%d", rows, row)
+				t.Errorf("expected panic for invalid row access N=%d r=%d", rows, row)
 			}
 		}
 		for _, col := range []int{-1, cols, cols + 1} {
 			panicked, message := panics(func() { m.Set(0, col, 1.2) })
 			if !panicked || message != ErrColAccess.Error() {
-				c.Errorf("expected panic for invalid column access N=%d c=%d", cols, col)
+				t.Errorf("expected panic for invalid column access N=%d c=%d", cols, col)
 			}
 		}
 	}
 }
 
-func (s *S) TestRowCol(c *check.C) {
+func TestRowCol(t *testing.T) {
 	for i, af := range [][][]float64{
 		{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
 		{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}},
@@ -236,7 +235,7 @@ func (s *S) TestRowCol(c *check.C) {
 		a := NewDense(flatten(af))
 		for ri, row := range af {
 			if got := Row(nil, ri, a); !reflect.DeepEqual(got, row) {
-				c.Errorf("unexpected row returned for test %d row %d: got: %v want: %v",
+				t.Errorf("unexpected row returned for test %d row %d: got: %v want: %v",
 					i, ri, got, row)
 			}
 		}
@@ -246,14 +245,14 @@ func (s *S) TestRowCol(c *check.C) {
 				col[j] = float64(ci + 1 + j*a.mat.Cols)
 			}
 			if got := Col(nil, ci, a); !reflect.DeepEqual(got, col) {
-				c.Errorf("unexpected col returned for test %d col %d: got: %v want: %v",
+				t.Errorf("unexpected col returned for test %d col %d: got: %v want: %v",
 					i, ci, got, col)
 			}
 		}
 	}
 }
 
-func (s *S) TestSetRowColumn(c *check.C) {
+func TestSetRowColumn(t *testing.T) {
 	for _, as := range [][][]float64{
 		{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
 		{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}},
@@ -268,7 +267,7 @@ func (s *S) TestSetRowColumn(c *check.C) {
 			nt := Norm(m, 2)
 			nr := floats.Norm(row, 2)
 			if math.Abs(nt-nr) > 1e-14 {
-				c.Errorf("Row %d norm mismatch, want: %g, got: %g", ri, nr, nt)
+				t.Errorf("Row %d norm mismatch, want: %g, got: %g", ri, nr, nt)
 			}
 		}
 
@@ -285,13 +284,13 @@ func (s *S) TestSetRowColumn(c *check.C) {
 			nt := Norm(m, 2)
 			nc := floats.Norm(col, 2)
 			if math.Abs(nt-nc) > 1e-14 {
-				c.Errorf("Column %d norm mismatch, want: %g, got: %g", ci, nc, nt)
+				t.Errorf("Column %d norm mismatch, want: %g, got: %g", ci, nc, nt)
 			}
 		}
 	}
 }
 
-func (s *S) TestRowColView(c *check.C) {
+func TestRowColView(t *testing.T) {
 	for _, test := range []struct {
 		mat [][]float64
 	}{
@@ -332,24 +331,24 @@ func (s *S) TestRowColView(c *check.C) {
 		for _, row := range []int{-1, rows, rows + 1} {
 			panicked, message := panics(func() { m.At(row, 0) })
 			if !panicked || message != ErrRowAccess.Error() {
-				c.Errorf("expected panic for invalid row access rows=%d r=%d", rows, row)
+				t.Errorf("expected panic for invalid row access rows=%d r=%d", rows, row)
 			}
 		}
 		for _, col := range []int{-1, cols, cols + 1} {
 			panicked, message := panics(func() { m.At(0, col) })
 			if !panicked || message != ErrColAccess.Error() {
-				c.Errorf("expected panic for invalid column access cols=%d c=%d", cols, col)
+				t.Errorf("expected panic for invalid column access cols=%d c=%d", cols, col)
 			}
 		}
 
 		for i := 0; i < rows; i++ {
 			vr := m.RowView(i)
 			if vr.Len() != cols {
-				c.Errorf("unexpected number of columns: got: %d want: %d", vr.Len(), cols)
+				t.Errorf("unexpected number of columns: got: %d want: %d", vr.Len(), cols)
 			}
 			for j := 0; j < cols; j++ {
 				if got := vr.At(j, 0); got != test.mat[i][j] {
-					c.Errorf("unexpected value for row.At(%d, 0): got: %v want: %v",
+					t.Errorf("unexpected value for row.At(%d, 0): got: %v want: %v",
 						j, got, test.mat[i][j])
 				}
 			}
@@ -357,11 +356,11 @@ func (s *S) TestRowColView(c *check.C) {
 		for j := 0; j < cols; j++ {
 			vc := m.ColView(j)
 			if vc.Len() != rows {
-				c.Errorf("unexpected number of rows: got: %d want: %d", vc.Len(), rows)
+				t.Errorf("unexpected number of rows: got: %d want: %d", vc.Len(), rows)
 			}
 			for i := 0; i < rows; i++ {
 				if got := vc.At(i, 0); got != test.mat[i][j] {
-					c.Errorf("unexpected value for col.At(%d, 0): got: %v want: %v",
+					t.Errorf("unexpected value for col.At(%d, 0): got: %v want: %v",
 						i, got, test.mat[i][j])
 				}
 			}
@@ -370,11 +369,11 @@ func (s *S) TestRowColView(c *check.C) {
 		for i := 1; i < rows-1; i++ {
 			vr := m.RowView(i - 1)
 			if vr.Len() != cols-2 {
-				c.Errorf("unexpected number of columns: got: %d want: %d", vr.Len(), cols-2)
+				t.Errorf("unexpected number of columns: got: %d want: %d", vr.Len(), cols-2)
 			}
 			for j := 1; j < cols-1; j++ {
 				if got := vr.At(j-1, 0); got != test.mat[i][j] {
-					c.Errorf("unexpected value for row.At(%d, 0): got: %v want: %v",
+					t.Errorf("unexpected value for row.At(%d, 0): got: %v want: %v",
 						j-1, got, test.mat[i][j])
 				}
 			}
@@ -382,11 +381,11 @@ func (s *S) TestRowColView(c *check.C) {
 		for j := 1; j < cols-1; j++ {
 			vc := m.ColView(j - 1)
 			if vc.Len() != rows-2 {
-				c.Errorf("unexpected number of rows: got: %d want: %d", vc.Len(), rows-2)
+				t.Errorf("unexpected number of rows: got: %d want: %d", vc.Len(), rows-2)
 			}
 			for i := 1; i < rows-1; i++ {
 				if got := vc.At(i-1, 0); got != test.mat[i][j] {
-					c.Errorf("unexpected value for col.At(%d, 0): got: %v want: %v",
+					t.Errorf("unexpected value for col.At(%d, 0): got: %v want: %v",
 						i-1, got, test.mat[i][j])
 				}
 			}
@@ -394,43 +393,43 @@ func (s *S) TestRowColView(c *check.C) {
 	}
 }
 
-func (s *S) TestGrow(c *check.C) {
+func TestGrow(t *testing.T) {
 	m := &Dense{}
 	m = m.Grow(10, 10).(*Dense)
 	rows, cols := m.Dims()
 	capRows, capCols := m.Caps()
 	if rows != 10 {
-		c.Errorf("unexpected value for rows: got: %d want: 10", rows)
+		t.Errorf("unexpected value for rows: got: %d want: 10", rows)
 	}
 	if cols != 10 {
-		c.Errorf("unexpected value for cols: got: %d want: 10", cols)
+		t.Errorf("unexpected value for cols: got: %d want: 10", cols)
 	}
 	if capRows != 10 {
-		c.Errorf("unexpected value for capRows: got: %d want: 10", capRows)
+		t.Errorf("unexpected value for capRows: got: %d want: 10", capRows)
 	}
 	if capCols != 10 {
-		c.Errorf("unexpected value for capCols: got: %d want: 10", capCols)
+		t.Errorf("unexpected value for capCols: got: %d want: 10", capCols)
 	}
 
 	// Test grow within caps is in-place.
 	m.Set(1, 1, 1)
 	v := m.View(1, 1, 4, 4).(*Dense)
 	if v.At(0, 0) != m.At(1, 1) {
-		c.Errorf("unexpected viewed element value: got: %v want: %v", v.At(0, 0), m.At(1, 1))
+		t.Errorf("unexpected viewed element value: got: %v want: %v", v.At(0, 0), m.At(1, 1))
 	}
 	v = v.Grow(5, 5).(*Dense)
 	if !Equal(v, m.View(1, 1, 9, 9)) {
-		c.Error("unexpected view value after grow")
+		t.Error("unexpected view value after grow")
 	}
 
 	// Test grow bigger than caps copies.
 	v = v.Grow(5, 5).(*Dense)
 	if !Equal(v.View(0, 0, 9, 9), m.View(1, 1, 9, 9)) {
-		c.Error("unexpected mismatched common view value after grow")
+		t.Error("unexpected mismatched common view value after grow")
 	}
 	v.Set(0, 0, 0)
 	if Equal(v.View(0, 0, 9, 9), m.View(1, 1, 9, 9)) {
-		c.Error("unexpected matching view value after grow past capacity")
+		t.Error("unexpected matching view value after grow past capacity")
 	}
 
 	// Test grow uses existing data slice when matrix is zero size.
@@ -439,17 +438,17 @@ func (s *S) TestGrow(c *check.C) {
 	*p = 1 // This element is at postion (-1, -1) relative to v and so should not be visible.
 	v = v.Grow(5, 5).(*Dense)
 	if &v.mat.Data[:1][0] != p {
-		c.Error("grow unexpectedly copied slice within cap limit")
+		t.Error("grow unexpectedly copied slice within cap limit")
 	}
 	if cap(v.mat.Data) != l {
-		c.Errorf("unexpected change in data slice capacity: got: %d want: %d", cap(v.mat.Data), l)
+		t.Errorf("unexpected change in data slice capacity: got: %d want: %d", cap(v.mat.Data), l)
 	}
 	if v.At(0, 0) != 0 {
-		c.Errorf("unexpected value for At(0, 0): got: %v want: 0", v.At(0, 0))
+		t.Errorf("unexpected value for At(0, 0): got: %v want: 0", v.At(0, 0))
 	}
 }
 
-func (s *S) TestAdd(c *check.C) {
+func TestAdd(t *testing.T) {
 	for i, test := range []struct {
 		a, b, r [][]float64
 	}{
@@ -486,14 +485,14 @@ func (s *S) TestAdd(c *check.C) {
 		var temp Dense
 		temp.Add(a, b)
 		if !Equal(&temp, r) {
-			c.Errorf("unexpected result from Add for test %d %v Add %v: got: %v want: %v",
+			t.Errorf("unexpected result from Add for test %d %v Add %v: got: %v want: %v",
 				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
 		}
 
 		zero(temp.mat.Data)
 		temp.Add(a, b)
 		if !Equal(&temp, r) {
-			c.Errorf("unexpected result from Add for test %d %v Add %v: got: %v want: %v",
+			t.Errorf("unexpected result from Add for test %d %v Add %v: got: %v want: %v",
 				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
 		}
 
@@ -501,12 +500,12 @@ func (s *S) TestAdd(c *check.C) {
 		temp.mat.Data = nil
 		panicked, message := panics(func() { temp.Add(a, b) })
 		if !panicked || message != "runtime error: index out of range" {
-			c.Error("exected runtime panic for nil data slice")
+			t.Error("exected runtime panic for nil data slice")
 		}
 
 		a.Add(a, b)
 		if !Equal(a, r) {
-			c.Errorf("unexpected result from Add for test %d %v Add %v: got: %v want: %v",
+			t.Errorf("unexpected result from Add for test %d %v Add %v: got: %v want: %v",
 				i, test.a, test.b, unflatten(a.mat.Rows, a.mat.Cols, a.mat.Data), test.r)
 		}
 	}
@@ -521,10 +520,10 @@ func (s *S) TestAdd(c *check.C) {
 	denseComparison := func(receiver, a, b *Dense) {
 		receiver.Add(a, b)
 	}
-	testTwoInput(c, "Add", &Dense{}, method, denseComparison, legalTypesAll, legalSizeSameRectangular, 1e-14)
+	testTwoInput(t, "Add", &Dense{}, method, denseComparison, legalTypesAll, legalSizeSameRectangular, 1e-14)
 }
 
-func (s *S) TestSub(c *check.C) {
+func TestSub(t *testing.T) {
 	for i, test := range []struct {
 		a, b, r [][]float64
 	}{
@@ -561,14 +560,14 @@ func (s *S) TestSub(c *check.C) {
 		var temp Dense
 		temp.Sub(a, b)
 		if !Equal(&temp, r) {
-			c.Errorf("unexpected result from Sub for test %d %v Sub %v: got: %v want: %v",
+			t.Errorf("unexpected result from Sub for test %d %v Sub %v: got: %v want: %v",
 				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
 		}
 
 		zero(temp.mat.Data)
 		temp.Sub(a, b)
 		if !Equal(&temp, r) {
-			c.Errorf("unexpected result from Sub for test %d %v Sub %v: got: %v want: %v",
+			t.Errorf("unexpected result from Sub for test %d %v Sub %v: got: %v want: %v",
 				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
 		}
 
@@ -576,18 +575,18 @@ func (s *S) TestSub(c *check.C) {
 		temp.mat.Data = nil
 		panicked, message := panics(func() { temp.Sub(a, b) })
 		if !panicked || message != "runtime error: index out of range" {
-			c.Error("exected runtime panic for nil data slice")
+			t.Error("exected runtime panic for nil data slice")
 		}
 
 		a.Sub(a, b)
 		if !Equal(a, r) {
-			c.Errorf("unexpected result from Sub for test %d %v Sub %v: got: %v want: %v",
+			t.Errorf("unexpected result from Sub for test %d %v Sub %v: got: %v want: %v",
 				i, test.a, test.b, unflatten(a.mat.Rows, a.mat.Cols, a.mat.Data), test.r)
 		}
 	}
 }
 
-func (s *S) TestMulElem(c *check.C) {
+func TestMulElem(t *testing.T) {
 	for i, test := range []struct {
 		a, b, r [][]float64
 	}{
@@ -624,14 +623,14 @@ func (s *S) TestMulElem(c *check.C) {
 		var temp Dense
 		temp.MulElem(a, b)
 		if !Equal(&temp, r) {
-			c.Errorf("unexpected result from MulElem for test %d %v MulElem %v: got: %v want: %v",
+			t.Errorf("unexpected result from MulElem for test %d %v MulElem %v: got: %v want: %v",
 				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
 		}
 
 		zero(temp.mat.Data)
 		temp.MulElem(a, b)
 		if !Equal(&temp, r) {
-			c.Errorf("unexpected result from MulElem for test %d %v MulElem %v: got: %v want: %v",
+			t.Errorf("unexpected result from MulElem for test %d %v MulElem %v: got: %v want: %v",
 				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
 		}
 
@@ -639,12 +638,12 @@ func (s *S) TestMulElem(c *check.C) {
 		temp.mat.Data = nil
 		panicked, message := panics(func() { temp.MulElem(a, b) })
 		if !panicked || message != "runtime error: index out of range" {
-			c.Error("exected runtime panic for nil data slice")
+			t.Error("exected runtime panic for nil data slice")
 		}
 
 		a.MulElem(a, b)
 		if !Equal(a, r) {
-			c.Errorf("unexpected result from MulElem for test %d %v MulElem %v: got: %v want: %v",
+			t.Errorf("unexpected result from MulElem for test %d %v MulElem %v: got: %v want: %v",
 				i, test.a, test.b, unflatten(a.mat.Rows, a.mat.Cols, a.mat.Data), test.r)
 		}
 	}
@@ -666,7 +665,7 @@ func (m *Dense) same(b Matrix) bool {
 	return true
 }
 
-func (s *S) TestDivElem(c *check.C) {
+func TestDivElem(t *testing.T) {
 	for i, test := range []struct {
 		a, b, r [][]float64
 	}{
@@ -703,14 +702,14 @@ func (s *S) TestDivElem(c *check.C) {
 		var temp Dense
 		temp.DivElem(a, b)
 		if !temp.same(r) {
-			c.Errorf("unexpected result from DivElem for test %d %v DivElem %v: got: %v want: %v",
+			t.Errorf("unexpected result from DivElem for test %d %v DivElem %v: got: %v want: %v",
 				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
 		}
 
 		zero(temp.mat.Data)
 		temp.DivElem(a, b)
 		if !temp.same(r) {
-			c.Errorf("unexpected result from DivElem for test %d %v DivElem %v: got: %v want: %v",
+			t.Errorf("unexpected result from DivElem for test %d %v DivElem %v: got: %v want: %v",
 				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
 		}
 
@@ -718,18 +717,18 @@ func (s *S) TestDivElem(c *check.C) {
 		temp.mat.Data = nil
 		panicked, message := panics(func() { temp.DivElem(a, b) })
 		if !panicked || message != "runtime error: index out of range" {
-			c.Error("exected runtime panic for nil data slice")
+			t.Error("exected runtime panic for nil data slice")
 		}
 
 		a.DivElem(a, b)
 		if !a.same(r) {
-			c.Errorf("unexpected result from DivElem for test %d %v DivElem %v: got: %v want: %v",
+			t.Errorf("unexpected result from DivElem for test %d %v DivElem %v: got: %v want: %v",
 				i, test.a, test.b, unflatten(a.mat.Rows, a.mat.Cols, a.mat.Data), test.r)
 		}
 	}
 }
 
-func (s *S) TestMul(c *check.C) {
+func TestMul(t *testing.T) {
 	for i, test := range []struct {
 		a, b, r [][]float64
 	}{
@@ -771,14 +770,14 @@ func (s *S) TestMul(c *check.C) {
 		var temp Dense
 		temp.Mul(a, b)
 		if !Equal(&temp, r) {
-			c.Errorf("unexpected result from Mul for test %d %v Mul %v: got: %v want: %v",
+			t.Errorf("unexpected result from Mul for test %d %v Mul %v: got: %v want: %v",
 				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
 		}
 
 		zero(temp.mat.Data)
 		temp.Mul(a, b)
 		if !Equal(&temp, r) {
-			c.Errorf("unexpected result from Mul for test %d %v Mul %v: got: %v want: %v",
+			t.Errorf("unexpected result from Mul for test %d %v Mul %v: got: %v want: %v",
 				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
 		}
 
@@ -786,7 +785,7 @@ func (s *S) TestMul(c *check.C) {
 		temp.mat.Data = nil
 		panicked, message := panics(func() { temp.Mul(a, b) })
 		if !panicked || message != "blas: index of c out of range" {
-			c.Error("exected runtime panic for nil data slice")
+			t.Error("exected runtime panic for nil data slice")
 		}
 	}
 
@@ -803,7 +802,7 @@ func (s *S) TestMul(c *check.C) {
 	legalSizeMul := func(ar, ac, br, bc int) bool {
 		return ac == br
 	}
-	testTwoInput(c, "Mul", &Dense{}, method, denseComparison, legalTypesAll, legalSizeMul, 1e-14)
+	testTwoInput(t, "Mul", &Dense{}, method, denseComparison, legalTypesAll, legalSizeMul, 1e-14)
 }
 
 func randDense(size int, rho float64, rnd func() float64) (*Dense, error) {
@@ -827,7 +826,7 @@ func randDense(size int, rho float64, rnd func() float64) (*Dense, error) {
 	return d, nil
 }
 
-func (s *S) TestExp(c *check.C) {
+func TestExp(t *testing.T) {
 	for i, test := range []struct {
 		a    [][]float64
 		want [][]float64
@@ -859,12 +858,12 @@ func (s *S) TestExp(c *check.C) {
 		}
 		got.Exp(NewDense(flatten(test.a)))
 		if !EqualApprox(&got, NewDense(flatten(test.want)), 1e-12) {
-			c.Errorf("unexpected result for Exp test %d", i)
+			t.Errorf("unexpected result for Exp test %d", i)
 		}
 	}
 }
 
-func (s *S) TestPow(c *check.C) {
+func TestPow(t *testing.T) {
 	for i, test := range []struct {
 		a    [][]float64
 		n    int
@@ -946,12 +945,12 @@ func (s *S) TestPow(c *check.C) {
 		}
 		got.Pow(NewDense(flatten(test.a)), test.n)
 		if !EqualApprox(&got, NewDense(flatten(test.want)), 1e-12) {
-			c.Errorf("unexpected result for Pow test %d", i)
+			t.Errorf("unexpected result for Pow test %d", i)
 		}
 	}
 }
 
-func (s *S) TestPowN(c *check.C) {
+func TestPowN(t *testing.T) {
 	for i, test := range []struct {
 		a    [][]float64
 		mod  func(*Dense)
@@ -979,7 +978,7 @@ func (s *S) TestPowN(c *check.C) {
 			got.Pow(NewDense(flatten(test.a)), n)
 			want.iterativePow(NewDense(flatten(test.a)), n)
 			if !Equal(&got, &want) {
-				c.Errorf("unexpected result for iterative Pow test %d", i)
+				t.Errorf("unexpected result for iterative Pow test %d", i)
 			}
 		}
 	}
@@ -992,7 +991,7 @@ func (m *Dense) iterativePow(a Matrix, n int) {
 	}
 }
 
-func (s *S) TestCloneT(c *check.C) {
+func TestCloneT(t *testing.T) {
 	for i, test := range []struct {
 		a, want [][]float64
 	}{
@@ -1025,12 +1024,12 @@ func (s *S) TestCloneT(c *check.C) {
 		for j := 0; j < 2; j++ {
 			got.Clone(a.T())
 			if !Equal(&got, want) {
-				c.Errorf("expected transpose for test %d iteration %d: %v transpose = %v",
+				t.Errorf("expected transpose for test %d iteration %d: %v transpose = %v",
 					i, j, test.a, test.want)
 			}
 			gotT.Clone(got.T())
 			if !Equal(&gotT, a) {
-				c.Errorf("expected transpose for test %d iteration %d: %v transpose = %v",
+				t.Errorf("expected transpose for test %d iteration %d: %v transpose = %v",
 					i, j, test.a, test.want)
 			}
 
@@ -1039,7 +1038,7 @@ func (s *S) TestCloneT(c *check.C) {
 	}
 }
 
-func (s *S) TestCopyT(c *check.C) {
+func TestCopyT(t *testing.T) {
 	for i, test := range []struct {
 		a, want [][]float64
 	}{
@@ -1074,12 +1073,12 @@ func (s *S) TestCopyT(c *check.C) {
 		for j := 0; j < 2; j++ {
 			got.Copy(a.T())
 			if !Equal(got, want) {
-				c.Errorf("expected transpose for test %d iteration %d: %v transpose = %v",
+				t.Errorf("expected transpose for test %d iteration %d: %v transpose = %v",
 					i, j, test.a, test.want)
 			}
 			rr.Copy(got.T())
 			if !Equal(rr, a) {
-				c.Errorf("expected transpose for test %d iteration %d: %v transpose = %v",
+				t.Errorf("expected transpose for test %d iteration %d: %v transpose = %v",
 					i, j, test.a, test.want)
 			}
 
@@ -1090,10 +1089,10 @@ func (s *S) TestCopyT(c *check.C) {
 
 func identity(r, c int, v float64) float64 { return v }
 
-func (s *S) TestApply(c *check.C) {
+func TestApply(t *testing.T) {
 	for i, test := range []struct {
 		a, want [][]float64
-		fn   func(r, c int, v float64) float64
+		fn      func(r, c int, v float64) float64
 	}{
 		{
 			[][]float64{{0, 0, 0}, {0, 0, 0}, {0, 0, 0}},
@@ -1154,13 +1153,13 @@ func (s *S) TestApply(c *check.C) {
 		for j := 0; j < 2; j++ {
 			got.Apply(test.fn, a)
 			if !Equal(&got, want) {
-				c.Errorf("unexpected result for test %d iteration %d: got: %v want: %v", i, j, got.mat.Data, want.mat.Data)
+				t.Errorf("unexpected result for test %d iteration %d: got: %v want: %v", i, j, got.mat.Data, want.mat.Data)
 			}
 		}
 	}
 }
 
-func (s *S) TestClone(c *check.C) {
+func TestClone(t *testing.T) {
 	for i, test := range []struct {
 		a    [][]float64
 		i, j int
@@ -1183,14 +1182,14 @@ func (s *S) TestClone(c *check.C) {
 		a.Set(test.i, test.j, test.v)
 
 		if Equal(&b, a) {
-			c.Errorf("unexpected mirror of write to cloned matrix for test %d: %v cloned and altered = %v",
+			t.Errorf("unexpected mirror of write to cloned matrix for test %d: %v cloned and altered = %v",
 				i, a, &b)
 		}
 	}
 }
 
 // TODO(kortschak) Roll this into testOneInput when it exists.
-func (s *S) TestCopyPanic(c *check.C) {
+func TestCopyPanic(t *testing.T) {
 	for _, a := range []*Dense{
 		&Dense{},
 		&Dense{mat: blas64.General{Rows: 1}},
@@ -1200,18 +1199,18 @@ func (s *S) TestCopyPanic(c *check.C) {
 		m := NewDense(1, 1, nil)
 		panicked, message := panics(func() { rows, cols = m.Copy(a) })
 		if panicked {
-			c.Errorf("unexpected panic: %v", message)
+			t.Errorf("unexpected panic: %v", message)
 		}
 		if rows != 0 {
-			c.Errorf("unexpected rows: got: %d want: 0", rows)
+			t.Errorf("unexpected rows: got: %d want: 0", rows)
 		}
 		if cols != 0 {
-			c.Errorf("unexpected cols: got: %d want: 0", cols)
+			t.Errorf("unexpected cols: got: %d want: 0", cols)
 		}
 	}
 }
 
-func (s *S) TestStack(c *check.C) {
+func TestStack(t *testing.T) {
 	for i, test := range []struct {
 		a, b, e [][]float64
 	}{
@@ -1238,12 +1237,12 @@ func (s *S) TestStack(c *check.C) {
 		s.Stack(a, b)
 
 		if !Equal(&s, NewDense(flatten(test.e))) {
-			c.Errorf("unexpected result for Stack test %d: %v stack %v = %v", i, a, b, s)
+			t.Errorf("unexpected result for Stack test %d: %v stack %v = %v", i, a, b, s)
 		}
 	}
 }
 
-func (s *S) TestAugment(c *check.C) {
+func TestAugment(t *testing.T) {
 	for i, test := range []struct {
 		a, b, e [][]float64
 	}{
@@ -1270,12 +1269,12 @@ func (s *S) TestAugment(c *check.C) {
 		s.Augment(a, b)
 
 		if !Equal(&s, NewDense(flatten(test.e))) {
-			c.Errorf("unexpected result for Augment test %d: %v augment %v = %v", i, a, b, s)
+			t.Errorf("unexpected result for Augment test %d: %v augment %v = %v", i, a, b, s)
 		}
 	}
 }
 
-func (s *S) TestRankOne(c *check.C) {
+func TestRankOne(t *testing.T) {
 	for i, test := range []struct {
 		x     []float64
 		y     []float64
@@ -1343,17 +1342,17 @@ func (s *S) TestRankOne(c *check.C) {
 		// Check with a new matrix
 		m.RankOne(a, test.alpha, NewVector(len(test.x), test.x), NewVector(len(test.y), test.y))
 		if !Equal(m, want) {
-			c.Errorf("unexpected result for RankOne test %d iteration 0: got: %+v want: %+v", i, m, want)
+			t.Errorf("unexpected result for RankOne test %d iteration 0: got: %+v want: %+v", i, m, want)
 		}
 		// Check with the same matrix
 		a.RankOne(a, test.alpha, NewVector(len(test.x), test.x), NewVector(len(test.y), test.y))
 		if !Equal(a, want) {
-			c.Errorf("unexpected result for Outer test %d iteration 1: got: %+v want: %+v", i, m, want)
+			t.Errorf("unexpected result for Outer test %d iteration 1: got: %+v want: %+v", i, m, want)
 		}
 	}
 }
 
-func (s *S) TestOuter(c *check.C) {
+func TestOuter(t *testing.T) {
 	for i, test := range []struct {
 		x []float64
 		y []float64
@@ -1395,13 +1394,13 @@ func (s *S) TestOuter(c *check.C) {
 			// Check with a new matrix - and then again.
 			m.Outer(NewVector(len(test.x), test.x), NewVector(len(test.y), test.y))
 			if !Equal(&m, want) {
-				c.Errorf("unexpected result for Outer test %d iteration %d: got: %+v want: %+v", i, j, m, want)
+				t.Errorf("unexpected result for Outer test %d iteration %d: got: %+v want: %+v", i, j, m, want)
 			}
 		}
 	}
 }
 
-func (s *S) TestInverse(c *check.C) {
+func TestInverse(t *testing.T) {
 	for i, test := range []struct {
 		a    *Dense
 		want *Dense
@@ -1439,10 +1438,10 @@ func (s *S) TestInverse(c *check.C) {
 		var got Dense
 		err := got.Inverse(test.a)
 		if err != nil {
-			c.Errorf("Error computing inverse: %v", err)
+			t.Errorf("Error computing inverse: %v", err)
 		}
 		if !equalApprox(&got, test.want, test.tol) {
-			c.Errorf("Case %d, inverse mismatch.", i)
+			t.Errorf("Case %d, inverse mismatch.", i)
 		}
 		var m Dense
 		m.Mul(&got, test.a)
@@ -1453,7 +1452,7 @@ func (s *S) TestInverse(c *check.C) {
 		}
 		eye := NewDense(r, r, d)
 		if !equalApprox(eye, &m, 1e-14) {
-			c.Errorf("Case %d, A^-1 * A != I", i)
+			t.Errorf("Case %d, A^-1 * A != I", i)
 		}
 	}
 }

--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -7,6 +7,7 @@ package mat64
 import (
 	"math"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/gonum/blas/blas64"
@@ -150,13 +151,27 @@ func (s *S) TestNewDense(c *check.C) {
 	} {
 		m := NewDense(test.rows, test.cols, test.a)
 		rows, cols := m.Dims()
-		c.Check(rows, check.Equals, test.rows, check.Commentf("Test %d", i))
-		c.Check(cols, check.Equals, test.cols, check.Commentf("Test %d", i))
-		c.Check(Min(m), check.Equals, test.min, check.Commentf("Test %d", i))
-		c.Check(Max(m), check.Equals, test.max, check.Commentf("Test %d", i))
-		c.Check(math.Abs(Norm(m, 2)-test.fro) > 1e-14, check.Equals, false, check.Commentf("Test %d", i))
-		c.Check(m, check.DeepEquals, test.mat, check.Commentf("Test %d", i))
-		c.Check(Equal(m, test.mat), check.Equals, true, check.Commentf("Test %d", i))
+		if rows != test.rows {
+			c.Errorf("unexpected number of rows for test %d: got: %d want: %d", i, rows, test.rows)
+		}
+		if cols != test.cols {
+			c.Errorf("unexpected number of cols for test %d: got: %d want: %d", i, cols, test.cols)
+		}
+		if min := Min(m); min != test.min {
+			c.Errorf("unexpected min for test %d: got: %v want: %v", i, min, test.min)
+		}
+		if max := Max(m); max != test.max {
+			c.Errorf("unexpected max for test %d: got: %v want: %v", i, max, test.max)
+		}
+		if fro := Norm(m, 2); math.Abs(Norm(m, 2)-test.fro) > 1e-14 {
+			c.Errorf("unexpected Frobenius norm for test %d: got: %v want: %v", i, fro, test.fro)
+		}
+		if !reflect.DeepEqual(m, test.mat) {
+			c.Errorf("unexpected matrix for test %d", i)
+		}
+		if !Equal(m, test.mat) {
+			c.Errorf("matrix does not equal expected matrix for test %d", i)
+		}
 	}
 }
 
@@ -170,28 +185,45 @@ func (s *S) TestAtSet(c *check.C) {
 		rows, cols := m.Dims()
 		for i := 0; i < rows; i++ {
 			for j := 0; j < cols; j++ {
-				c.Check(m.At(i, j), check.Equals, af[i][j], check.Commentf("At test %d", test))
+				if m.At(i, j) != af[i][j] {
+					c.Errorf("unexpected value for At(%d, %d) for test %d: got: %v want: %v", m.At(i, j), af[i][j])
+				}
 
 				v := float64(i * j)
 				m.Set(i, j, v)
-				c.Check(m.At(i, j), check.Equals, v, check.Commentf("Set test %d", test))
+				if m.At(i, j) != v {
+					c.Errorf("unexpected value for At(%d, %d) after Set(%[1]d, %d, %v) for test %d: got: %v want: %[3]v",
+						i, j, v, test, m.At(i, j))
+				}
 			}
 		}
 		// Check access out of bounds fails
-		c.Check(func() { m.At(rows, 0) }, check.PanicMatches, ErrRowAccess.Error(), check.Commentf("Test %d", test))
-		c.Check(func() { m.At(rows+1, 0) }, check.PanicMatches, ErrRowAccess.Error(), check.Commentf("Test %d", test))
-		c.Check(func() { m.At(0, cols) }, check.PanicMatches, ErrColAccess.Error(), check.Commentf("Test %d", test))
-		c.Check(func() { m.At(0, cols+1) }, check.PanicMatches, ErrColAccess.Error(), check.Commentf("Test %d", test))
-		c.Check(func() { m.At(-1, 0) }, check.PanicMatches, ErrRowAccess.Error(), check.Commentf("Test %d", test))
-		c.Check(func() { m.At(0, -1) }, check.PanicMatches, ErrColAccess.Error(), check.Commentf("Test %d", test))
+		for _, row := range []int{-1, rows, rows + 1} {
+			panicked, message := panics(func() { m.At(row, 0) })
+			if !panicked || message != ErrRowAccess.Error() {
+				c.Errorf("expected panic for invalid row access N=%d r=%d", rows, row)
+			}
+		}
+		for _, col := range []int{-1, cols, cols + 1} {
+			panicked, message := panics(func() { m.At(0, col) })
+			if !panicked || message != ErrColAccess.Error() {
+				c.Errorf("expected panic for invalid column access N=%d c=%d", cols, col)
+			}
+		}
 
-		// Check access out of bounds fails
-		c.Check(func() { m.Set(rows, 0, 1.2) }, check.PanicMatches, ErrRowAccess.Error(), check.Commentf("Test %d", test))
-		c.Check(func() { m.Set(rows+1, 0, 1.2) }, check.PanicMatches, ErrRowAccess.Error(), check.Commentf("Test %d", test))
-		c.Check(func() { m.Set(0, cols, 1.2) }, check.PanicMatches, ErrColAccess.Error(), check.Commentf("Test %d", test))
-		c.Check(func() { m.Set(0, cols+1, 1.2) }, check.PanicMatches, ErrColAccess.Error(), check.Commentf("Test %d", test))
-		c.Check(func() { m.Set(-1, 0, 1.2) }, check.PanicMatches, ErrRowAccess.Error(), check.Commentf("Test %d", test))
-		c.Check(func() { m.Set(0, -1, 1.2) }, check.PanicMatches, ErrColAccess.Error(), check.Commentf("Test %d", test))
+		// Check Set out of bounds
+		for _, row := range []int{-1, rows, rows + 1} {
+			panicked, message := panics(func() { m.Set(row, 0, 1.2) })
+			if !panicked || message != ErrRowAccess.Error() {
+				c.Errorf("expected panic for invalid row access N=%d r=%d", rows, row)
+			}
+		}
+		for _, col := range []int{-1, cols, cols + 1} {
+			panicked, message := panics(func() { m.Set(0, col, 1.2) })
+			if !panicked || message != ErrColAccess.Error() {
+				c.Errorf("expected panic for invalid column access N=%d c=%d", cols, col)
+			}
+		}
 	}
 }
 
@@ -203,14 +235,20 @@ func (s *S) TestRowCol(c *check.C) {
 	} {
 		a := NewDense(flatten(af))
 		for ri, row := range af {
-			c.Check(Row(nil, ri, a), check.DeepEquals, row, check.Commentf("Test %d", i))
+			if got := Row(nil, ri, a); !reflect.DeepEqual(got, row) {
+				c.Errorf("unexpected row returned for test %d row %d: got: %v want: %v",
+					i, ri, got, row)
+			}
 		}
 		for ci := range af[0] {
 			col := make([]float64, a.mat.Rows)
 			for j := range col {
 				col[j] = float64(ci + 1 + j*a.mat.Cols)
 			}
-			c.Check(Col(nil, ci, a), check.DeepEquals, col, check.Commentf("Test %d", i))
+			if got := Col(nil, ci, a); !reflect.DeepEqual(got, col) {
+				c.Errorf("unexpected col returned for test %d col %d: got: %v want: %v",
+					i, ci, got, col)
+			}
 		}
 	}
 }
@@ -223,11 +261,11 @@ func (s *S) TestSetRowColumn(c *check.C) {
 	} {
 		for ri, row := range as {
 			a := NewDense(flatten(as))
-			t := &Dense{}
-			t.Clone(a)
+			m := &Dense{}
+			m.Clone(a)
 			a.SetRow(ri, make([]float64, a.mat.Cols))
-			t.Sub(t, a)
-			nt := Norm(t, 2)
+			m.Sub(m, a)
+			nt := Norm(m, 2)
 			nr := floats.Norm(row, 2)
 			if math.Abs(nt-nr) > 1e-14 {
 				c.Errorf("Row %d norm mismatch, want: %g, got: %g", ri, nr, nt)
@@ -236,15 +274,15 @@ func (s *S) TestSetRowColumn(c *check.C) {
 
 		for ci := range as[0] {
 			a := NewDense(flatten(as))
-			t := &Dense{}
-			t.Clone(a)
+			m := &Dense{}
+			m.Clone(a)
 			a.SetCol(ci, make([]float64, a.mat.Rows))
 			col := make([]float64, a.mat.Rows)
 			for j := range col {
 				col[j] = float64(ci + 1 + j*a.mat.Cols)
 			}
-			t.Sub(t, a)
-			nt := Norm(t, 2)
+			m.Sub(m, a)
+			nt := Norm(m, 2)
 			nc := floats.Norm(col, 2)
 			if math.Abs(nt-nc) > 1e-14 {
 				c.Errorf("Column %d norm mismatch, want: %g, got: %g", ci, nc, nt)
@@ -291,38 +329,66 @@ func (s *S) TestRowColView(c *check.C) {
 		rows, cols, flat := flatten(test.mat)
 		m := NewDense(rows, cols, flat[:len(flat):len(flat)])
 
-		c.Check(func() { m.RowView(-1) }, check.PanicMatches, ErrRowAccess.Error())
-		c.Check(func() { m.RowView(rows) }, check.PanicMatches, ErrRowAccess.Error())
-		c.Check(func() { m.ColView(-1) }, check.PanicMatches, ErrColAccess.Error())
-		c.Check(func() { m.ColView(cols) }, check.PanicMatches, ErrColAccess.Error())
+		for _, row := range []int{-1, rows, rows + 1} {
+			panicked, message := panics(func() { m.At(row, 0) })
+			if !panicked || message != ErrRowAccess.Error() {
+				c.Errorf("expected panic for invalid row access rows=%d r=%d", rows, row)
+			}
+		}
+		for _, col := range []int{-1, cols, cols + 1} {
+			panicked, message := panics(func() { m.At(0, col) })
+			if !panicked || message != ErrColAccess.Error() {
+				c.Errorf("expected panic for invalid column access cols=%d c=%d", cols, col)
+			}
+		}
 
 		for i := 0; i < rows; i++ {
 			vr := m.RowView(i)
-			c.Check(vr.Len(), check.Equals, cols)
+			if vr.Len() != cols {
+				c.Errorf("unexpected number of columns: got: %d want: %d", vr.Len(), cols)
+			}
 			for j := 0; j < cols; j++ {
-				c.Check(vr.At(j, 0), check.Equals, test.mat[i][j])
+				if got := vr.At(j, 0); got != test.mat[i][j] {
+					c.Errorf("unexpected value for row.At(%d, 0): got: %v want: %v",
+						j, got, test.mat[i][j])
+				}
 			}
 		}
 		for j := 0; j < cols; j++ {
-			vr := m.ColView(j)
-			c.Check(vr.Len(), check.Equals, rows)
+			vc := m.ColView(j)
+			if vc.Len() != rows {
+				c.Errorf("unexpected number of rows: got: %d want: %d", vc.Len(), rows)
+			}
 			for i := 0; i < rows; i++ {
-				c.Check(vr.At(i, 0), check.Equals, test.mat[i][j])
+				if got := vc.At(i, 0); got != test.mat[i][j] {
+					c.Errorf("unexpected value for col.At(%d, 0): got: %v want: %v",
+						i, got, test.mat[i][j])
+				}
 			}
 		}
 		m = m.View(1, 1, rows-2, cols-2).(*Dense)
 		for i := 1; i < rows-1; i++ {
 			vr := m.RowView(i - 1)
-			c.Check(vr.Len(), check.Equals, cols-2)
+			if vr.Len() != cols-2 {
+				c.Errorf("unexpected number of columns: got: %d want: %d", vr.Len(), cols-2)
+			}
 			for j := 1; j < cols-1; j++ {
-				c.Check(vr.At(j-1, 0), check.Equals, test.mat[i][j])
+				if got := vr.At(j-1, 0); got != test.mat[i][j] {
+					c.Errorf("unexpected value for row.At(%d, 0): got: %v want: %v",
+						j-1, got, test.mat[i][j])
+				}
 			}
 		}
 		for j := 1; j < cols-1; j++ {
-			vr := m.ColView(j - 1)
-			c.Check(vr.Len(), check.Equals, rows-2)
+			vc := m.ColView(j - 1)
+			if vc.Len() != rows-2 {
+				c.Errorf("unexpected number of rows: got: %d want: %d", vc.Len(), rows-2)
+			}
 			for i := 1; i < rows-1; i++ {
-				c.Check(vr.At(i-1, 0), check.Equals, test.mat[i][j])
+				if got := vc.At(i-1, 0); got != test.mat[i][j] {
+					c.Errorf("unexpected value for col.At(%d, 0): got: %v want: %v",
+						i-1, got, test.mat[i][j])
+				}
 			}
 		}
 	}
@@ -333,32 +399,54 @@ func (s *S) TestGrow(c *check.C) {
 	m = m.Grow(10, 10).(*Dense)
 	rows, cols := m.Dims()
 	capRows, capCols := m.Caps()
-	c.Check(rows, check.Equals, 10)
-	c.Check(cols, check.Equals, 10)
-	c.Check(capRows, check.Equals, 10)
-	c.Check(capCols, check.Equals, 10)
+	if rows != 10 {
+		c.Errorf("unexpected value for rows: got: %d want: 10", rows)
+	}
+	if cols != 10 {
+		c.Errorf("unexpected value for cols: got: %d want: 10", cols)
+	}
+	if capRows != 10 {
+		c.Errorf("unexpected value for capRows: got: %d want: 10", capRows)
+	}
+	if capCols != 10 {
+		c.Errorf("unexpected value for capCols: got: %d want: 10", capCols)
+	}
 
 	// Test grow within caps is in-place.
 	m.Set(1, 1, 1)
 	v := m.View(1, 1, 4, 4).(*Dense)
-	c.Check(v.At(0, 0), check.Equals, m.At(1, 1))
+	if v.At(0, 0) != m.At(1, 1) {
+		c.Errorf("unexpected viewed element value: got: %v want: %v", v.At(0, 0), m.At(1, 1))
+	}
 	v = v.Grow(5, 5).(*Dense)
-	c.Check(Equal(v, m.View(1, 1, 9, 9)), check.Equals, true)
+	if !Equal(v, m.View(1, 1, 9, 9)) {
+		c.Error("unexpected view value after grow")
+	}
 
 	// Test grow bigger than caps copies.
 	v = v.Grow(5, 5).(*Dense)
-	c.Check(Equal(v.View(0, 0, 9, 9), m.View(1, 1, 9, 9)), check.Equals, true)
+	if !Equal(v.View(0, 0, 9, 9), m.View(1, 1, 9, 9)) {
+		c.Error("unexpected mismatched common view value after grow")
+	}
 	v.Set(0, 0, 0)
-	c.Check(Equal(v.View(0, 0, 9, 9), m.View(1, 1, 9, 9)), check.Equals, false)
+	if Equal(v.View(0, 0, 9, 9), m.View(1, 1, 9, 9)) {
+		c.Error("unexpected matching view value after grow past capacity")
+	}
 
 	// Test grow uses existing data slice when matrix is zero size.
 	v.Reset()
 	p, l := &v.mat.Data[:1][0], cap(v.mat.Data)
-	*p = 1
+	*p = 1 // This element is at postion (-1, -1) relative to v and so should not be visible.
 	v = v.Grow(5, 5).(*Dense)
-	c.Check(&v.mat.Data[:1][0], check.Equals, p)
-	c.Check(cap(v.mat.Data), check.Equals, l)
-	c.Check(v.At(0, 0), check.Equals, 0.)
+	if &v.mat.Data[:1][0] != p {
+		c.Error("grow unexpectedly copied slice within cap limit")
+	}
+	if cap(v.mat.Data) != l {
+		c.Errorf("unexpected change in data slice capacity: got: %d want: %d", cap(v.mat.Data), l)
+	}
+	if v.At(0, 0) != 0 {
+		c.Errorf("unexpected value for At(0, 0): got: %v want: 0", v.At(0, 0))
+	}
 }
 
 func (s *S) TestAdd(c *check.C) {
@@ -397,21 +485,30 @@ func (s *S) TestAdd(c *check.C) {
 
 		var temp Dense
 		temp.Add(a, b)
-		c.Check(Equal(&temp, r), check.Equals, true, check.Commentf("Test %d: %v Add %v expect %v got %v",
-			i, test.a, test.b, test.r, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data)))
+		if !Equal(&temp, r) {
+			c.Errorf("unexpected result from Add for test %d %v Add %v: got: %v want: %v",
+				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
+		}
 
 		zero(temp.mat.Data)
 		temp.Add(a, b)
-		c.Check(Equal(&temp, r), check.Equals, true, check.Commentf("Test %d: %v Add %v expect %v got %v",
-			i, test.a, test.b, test.r, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data)))
+		if !Equal(&temp, r) {
+			c.Errorf("unexpected result from Add for test %d %v Add %v: got: %v want: %v",
+				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
+		}
 
 		// These probably warrant a better check and failure. They should never happen in the wild though.
 		temp.mat.Data = nil
-		c.Check(func() { temp.Add(a, b) }, check.PanicMatches, "runtime error: index out of range", check.Commentf("Test %d", i))
+		panicked, message := panics(func() { temp.Add(a, b) })
+		if !panicked || message != "runtime error: index out of range" {
+			c.Error("exected runtime panic for nil data slice")
+		}
 
 		a.Add(a, b)
-		c.Check(Equal(a, r), check.Equals, true, check.Commentf("Test %d: %v Add %v expect %v got %v",
-			i, test.a, test.b, test.r, unflatten(a.mat.Rows, a.mat.Cols, a.mat.Data)))
+		if !Equal(a, r) {
+			c.Errorf("unexpected result from Add for test %d %v Add %v: got: %v want: %v",
+				i, test.a, test.b, unflatten(a.mat.Rows, a.mat.Cols, a.mat.Data), test.r)
+		}
 	}
 
 	method := func(receiver, a, b Matrix) {
@@ -463,21 +560,30 @@ func (s *S) TestSub(c *check.C) {
 
 		var temp Dense
 		temp.Sub(a, b)
-		c.Check(Equal(&temp, r), check.Equals, true, check.Commentf("Test %d: %v Sub %v expect %v got %v",
-			i, test.a, test.b, test.r, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data)))
+		if !Equal(&temp, r) {
+			c.Errorf("unexpected result from Sub for test %d %v Sub %v: got: %v want: %v",
+				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
+		}
 
 		zero(temp.mat.Data)
 		temp.Sub(a, b)
-		c.Check(Equal(&temp, r), check.Equals, true, check.Commentf("Test %d: %v Sub %v expect %v got %v",
-			i, test.a, test.b, test.r, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data)))
+		if !Equal(&temp, r) {
+			c.Errorf("unexpected result from Sub for test %d %v Sub %v: got: %v want: %v",
+				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
+		}
 
 		// These probably warrant a better check and failure. They should never happen in the wild though.
 		temp.mat.Data = nil
-		c.Check(func() { temp.Sub(a, b) }, check.PanicMatches, "runtime error: index out of range", check.Commentf("Test %d", i))
+		panicked, message := panics(func() { temp.Sub(a, b) })
+		if !panicked || message != "runtime error: index out of range" {
+			c.Error("exected runtime panic for nil data slice")
+		}
 
 		a.Sub(a, b)
-		c.Check(Equal(a, r), check.Equals, true, check.Commentf("Test %d: %v Sub %v expect %v got %v",
-			i, test.a, test.b, test.r, unflatten(a.mat.Rows, a.mat.Cols, a.mat.Data)))
+		if !Equal(a, r) {
+			c.Errorf("unexpected result from Sub for test %d %v Sub %v: got: %v want: %v",
+				i, test.a, test.b, unflatten(a.mat.Rows, a.mat.Cols, a.mat.Data), test.r)
+		}
 	}
 }
 
@@ -517,21 +623,30 @@ func (s *S) TestMulElem(c *check.C) {
 
 		var temp Dense
 		temp.MulElem(a, b)
-		c.Check(Equal(&temp, r), check.Equals, true, check.Commentf("Test %d: %v MulElem %v expect %v got %v",
-			i, test.a, test.b, test.r, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data)))
+		if !Equal(&temp, r) {
+			c.Errorf("unexpected result from MulElem for test %d %v MulElem %v: got: %v want: %v",
+				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
+		}
 
 		zero(temp.mat.Data)
 		temp.MulElem(a, b)
-		c.Check(Equal(&temp, r), check.Equals, true, check.Commentf("Test %d: %v MulElem %v expect %v got %v",
-			i, test.a, test.b, test.r, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data)))
+		if !Equal(&temp, r) {
+			c.Errorf("unexpected result from MulElem for test %d %v MulElem %v: got: %v want: %v",
+				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
+		}
 
 		// These probably warrant a better check and failure. They should never happen in the wild though.
 		temp.mat.Data = nil
-		c.Check(func() { temp.MulElem(a, b) }, check.PanicMatches, "runtime error: index out of range", check.Commentf("Test %d", i))
+		panicked, message := panics(func() { temp.MulElem(a, b) })
+		if !panicked || message != "runtime error: index out of range" {
+			c.Error("exected runtime panic for nil data slice")
+		}
 
 		a.MulElem(a, b)
-		c.Check(Equal(a, r), check.Equals, true, check.Commentf("Test %d: %v MulElem %v expect %v got %v",
-			i, test.a, test.b, test.r, unflatten(a.mat.Rows, a.mat.Cols, a.mat.Data)))
+		if !Equal(a, r) {
+			c.Errorf("unexpected result from MulElem for test %d %v MulElem %v: got: %v want: %v",
+				i, test.a, test.b, unflatten(a.mat.Rows, a.mat.Cols, a.mat.Data), test.r)
+		}
 	}
 }
 
@@ -587,21 +702,30 @@ func (s *S) TestDivElem(c *check.C) {
 
 		var temp Dense
 		temp.DivElem(a, b)
-		c.Check(temp.same(r), check.Equals, true, check.Commentf("Test %d: %v DivElem %v expect %v got %v",
-			i, test.a, test.b, test.r, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data)))
+		if !temp.same(r) {
+			c.Errorf("unexpected result from DivElem for test %d %v DivElem %v: got: %v want: %v",
+				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
+		}
 
 		zero(temp.mat.Data)
 		temp.DivElem(a, b)
-		c.Check(temp.same(r), check.Equals, true, check.Commentf("Test %d: %v DivElem %v expect %v got %v",
-			i, test.a, test.b, test.r, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data)))
+		if !temp.same(r) {
+			c.Errorf("unexpected result from DivElem for test %d %v DivElem %v: got: %v want: %v",
+				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
+		}
 
 		// These probably warrant a better check and failure. They should never happen in the wild though.
 		temp.mat.Data = nil
-		c.Check(func() { temp.DivElem(a, b) }, check.PanicMatches, "runtime error: index out of range", check.Commentf("Test %d", i))
+		panicked, message := panics(func() { temp.DivElem(a, b) })
+		if !panicked || message != "runtime error: index out of range" {
+			c.Error("exected runtime panic for nil data slice")
+		}
 
 		a.DivElem(a, b)
-		c.Check(a.same(r), check.Equals, true, check.Commentf("Test %d: %v DivElem %v expect %v got %v",
-			i, test.a, test.b, test.r, unflatten(a.mat.Rows, a.mat.Cols, a.mat.Data)))
+		if !a.same(r) {
+			c.Errorf("unexpected result from DivElem for test %d %v DivElem %v: got: %v want: %v",
+				i, test.a, test.b, unflatten(a.mat.Rows, a.mat.Cols, a.mat.Data), test.r)
+		}
 	}
 }
 
@@ -646,17 +770,24 @@ func (s *S) TestMul(c *check.C) {
 
 		var temp Dense
 		temp.Mul(a, b)
-		c.Check(Equal(&temp, r), check.Equals, true, check.Commentf("Test %d: %v Mul %v expect %v got %v",
-			i, test.a, test.b, test.r, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data)))
+		if !Equal(&temp, r) {
+			c.Errorf("unexpected result from Mul for test %d %v Mul %v: got: %v want: %v",
+				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
+		}
 
 		zero(temp.mat.Data)
 		temp.Mul(a, b)
-		c.Check(Equal(&temp, r), check.Equals, true, check.Commentf("Test %d: %v Mul %v expect %v got %v",
-			i, test.a, test.b, test.r, unflatten(a.mat.Rows, a.mat.Cols, a.mat.Data)))
+		if !Equal(&temp, r) {
+			c.Errorf("unexpected result from Mul for test %d %v Mul %v: got: %v want: %v",
+				i, test.a, test.b, unflatten(temp.mat.Rows, temp.mat.Cols, temp.mat.Data), test.r)
+		}
 
 		// These probably warrant a better check and failure. They should never happen in the wild though.
 		temp.mat.Data = nil
-		c.Check(func() { temp.Mul(a, b) }, check.PanicMatches, "blas: index of c out of range", check.Commentf("Test %d", i))
+		panicked, message := panics(func() { temp.Mul(a, b) })
+		if !panicked || message != "blas: index of c out of range" {
+			c.Error("exected runtime panic for nil data slice")
+		}
 	}
 
 	method := func(receiver, a, b Matrix) {
@@ -697,7 +828,7 @@ func randDense(size int, rho float64, rnd func() float64) (*Dense, error) {
 }
 
 func (s *S) TestExp(c *check.C) {
-	for i, t := range []struct {
+	for i, test := range []struct {
 		a    [][]float64
 		want [][]float64
 		mod  func(*Dense)
@@ -723,16 +854,18 @@ func (s *S) TestExp(c *check.C) {
 		},
 	} {
 		var got Dense
-		if t.mod != nil {
-			t.mod(&got)
+		if test.mod != nil {
+			test.mod(&got)
 		}
-		got.Exp(NewDense(flatten(t.a)))
-		c.Check(EqualApprox(&got, NewDense(flatten(t.want)), 1e-12), check.Equals, true, check.Commentf("Test %d", i))
+		got.Exp(NewDense(flatten(test.a)))
+		if !EqualApprox(&got, NewDense(flatten(test.want)), 1e-12) {
+			c.Errorf("unexpected result for Exp test %d", i)
+		}
 	}
 }
 
 func (s *S) TestPow(c *check.C) {
-	for i, t := range []struct {
+	for i, test := range []struct {
 		a    [][]float64
 		n    int
 		mod  func(*Dense)
@@ -808,16 +941,18 @@ func (s *S) TestPow(c *check.C) {
 		},
 	} {
 		var got Dense
-		if t.mod != nil {
-			t.mod(&got)
+		if test.mod != nil {
+			test.mod(&got)
 		}
-		got.Pow(NewDense(flatten(t.a)), t.n)
-		c.Check(Equal(&got, NewDense(flatten(t.want))), check.Equals, true, check.Commentf("Test %d", i))
+		got.Pow(NewDense(flatten(test.a)), test.n)
+		if !EqualApprox(&got, NewDense(flatten(test.want)), 1e-12) {
+			c.Errorf("unexpected result for Pow test %d", i)
+		}
 	}
 }
 
 func (s *S) TestPowN(c *check.C) {
-	for i, t := range []struct {
+	for i, test := range []struct {
 		a    [][]float64
 		mod  func(*Dense)
 		want [][]float64
@@ -838,12 +973,14 @@ func (s *S) TestPowN(c *check.C) {
 	} {
 		for n := 1; n <= 14; n++ {
 			var got, want Dense
-			if t.mod != nil {
-				t.mod(&got)
+			if test.mod != nil {
+				test.mod(&got)
 			}
-			got.Pow(NewDense(flatten(t.a)), n)
-			want.iterativePow(NewDense(flatten(t.a)), n)
-			c.Check(Equal(&got, &want), check.Equals, true, check.Commentf("Test %d", i))
+			got.Pow(NewDense(flatten(test.a)), n)
+			want.iterativePow(NewDense(flatten(test.a)), n)
+			if !Equal(&got, &want) {
+				c.Errorf("unexpected result for iterative Pow test %d", i)
+			}
 		}
 	}
 }
@@ -857,7 +994,7 @@ func (m *Dense) iterativePow(a Matrix, n int) {
 
 func (s *S) TestCloneT(c *check.C) {
 	for i, test := range []struct {
-		a, t [][]float64
+		a, want [][]float64
 	}{
 		{
 			[][]float64{{0, 0, 0}, {0, 0, 0}, {0, 0, 0}},
@@ -881,29 +1018,30 @@ func (s *S) TestCloneT(c *check.C) {
 		},
 	} {
 		a := NewDense(flatten(test.a))
-		t := NewDense(flatten(test.t))
+		want := NewDense(flatten(test.want))
 
-		var r, rr Dense
+		var got, gotT Dense
 
-		r.Clone(a.T())
-		c.Check(Equal(&r, t), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
+		for j := 0; j < 2; j++ {
+			got.Clone(a.T())
+			if !Equal(&got, want) {
+				c.Errorf("expected transpose for test %d iteration %d: %v transpose = %v",
+					i, j, test.a, test.want)
+			}
+			gotT.Clone(got.T())
+			if !Equal(&gotT, a) {
+				c.Errorf("expected transpose for test %d iteration %d: %v transpose = %v",
+					i, j, test.a, test.want)
+			}
 
-		rr.Clone(r.T())
-		c.Check(Equal(&rr, a), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
-
-		zero(r.mat.Data)
-		r.Clone(a.T())
-		c.Check(Equal(&r, t), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
-
-		zero(rr.mat.Data)
-		rr.Clone(r.T())
-		c.Check(Equal(&rr, a), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
+			zero(got.mat.Data)
+		}
 	}
 }
 
 func (s *S) TestCopyT(c *check.C) {
 	for i, test := range []struct {
-		a, t [][]float64
+		a, want [][]float64
 	}{
 		{
 			[][]float64{{0, 0, 0}, {0, 0, 0}, {0, 0, 0}},
@@ -927,25 +1065,26 @@ func (s *S) TestCopyT(c *check.C) {
 		},
 	} {
 		a := NewDense(flatten(test.a))
-		t := NewDense(flatten(test.t))
+		want := NewDense(flatten(test.want))
 
 		ar, ac := a.Dims()
-		r := NewDense(ac, ar, nil)
+		got := NewDense(ac, ar, nil)
 		rr := NewDense(ar, ac, nil)
 
-		r.Copy(a.T())
-		c.Check(Equal(r, t), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
+		for j := 0; j < 2; j++ {
+			got.Copy(a.T())
+			if !Equal(got, want) {
+				c.Errorf("expected transpose for test %d iteration %d: %v transpose = %v",
+					i, j, test.a, test.want)
+			}
+			rr.Copy(got.T())
+			if !Equal(rr, a) {
+				c.Errorf("expected transpose for test %d iteration %d: %v transpose = %v",
+					i, j, test.a, test.want)
+			}
 
-		rr.Copy(r.T())
-		c.Check(Equal(rr, a), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
-
-		zero(r.mat.Data)
-		r.Copy(a.T())
-		c.Check(Equal(r, t), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
-
-		zero(rr.mat.Data)
-		rr.Copy(r.T())
-		c.Check(Equal(rr, a), check.Equals, true, check.Commentf("Test %d: %v transpose = %v", i, test.a, test.t))
+			zero(got.mat.Data)
+		}
 	}
 }
 
@@ -953,7 +1092,7 @@ func identity(r, c int, v float64) float64 { return v }
 
 func (s *S) TestApply(c *check.C) {
 	for i, test := range []struct {
-		a, t [][]float64
+		a, want [][]float64
 		fn   func(r, c int, v float64) float64
 	}{
 		{
@@ -1008,15 +1147,16 @@ func (s *S) TestApply(c *check.C) {
 		},
 	} {
 		a := NewDense(flatten(test.a))
-		t := NewDense(flatten(test.t))
+		want := NewDense(flatten(test.want))
 
-		var r Dense
+		var got Dense
 
-		r.Apply(test.fn, a)
-		c.Check(Equal(&r, t), check.Equals, true, check.Commentf("Test %d: obtained %v expect: %v", i, r.mat.Data, t.mat.Data))
-
-		a.Apply(test.fn, a)
-		c.Check(Equal(a, t), check.Equals, true, check.Commentf("Test %d: obtained %v expect: %v", i, a.mat.Data, t.mat.Data))
+		for j := 0; j < 2; j++ {
+			got.Apply(test.fn, a)
+			if !Equal(&got, want) {
+				c.Errorf("unexpected result for test %d iteration %d: got: %v want: %v", i, j, got.mat.Data, want.mat.Data)
+			}
+		}
 	}
 }
 
@@ -1042,7 +1182,10 @@ func (s *S) TestClone(c *check.C) {
 		a.Clone(a)
 		a.Set(test.i, test.j, test.v)
 
-		c.Check(Equal(&b, a), check.Equals, false, check.Commentf("Test %d: %v cloned and altered = %v", i, a, &b))
+		if Equal(&b, a) {
+			c.Errorf("unexpected mirror of write to cloned matrix for test %d: %v cloned and altered = %v",
+				i, a, &b)
+		}
 	}
 }
 
@@ -1055,10 +1198,16 @@ func (s *S) TestCopyPanic(c *check.C) {
 	} {
 		var rows, cols int
 		m := NewDense(1, 1, nil)
-		panicked, _ := panics(func() { rows, cols = m.Copy(a) })
-		c.Check(panicked, check.Equals, false)
-		c.Check(rows, check.Equals, 0)
-		c.Check(cols, check.Equals, 0)
+		panicked, message := panics(func() { rows, cols = m.Copy(a) })
+		if panicked {
+			c.Errorf("unexpected panic: %v", message)
+		}
+		if rows != 0 {
+			c.Errorf("unexpected rows: got: %d want: 0", rows)
+		}
+		if cols != 0 {
+			c.Errorf("unexpected cols: got: %d want: 0", cols)
+		}
 	}
 }
 
@@ -1088,7 +1237,9 @@ func (s *S) TestStack(c *check.C) {
 		var s Dense
 		s.Stack(a, b)
 
-		c.Check(Equal(&s, NewDense(flatten(test.e))), check.Equals, true, check.Commentf("Test %d: %v stack %v = %v", i, a, b, s))
+		if !Equal(&s, NewDense(flatten(test.e))) {
+			c.Errorf("unexpected result for Stack test %d: %v stack %v = %v", i, a, b, s)
+		}
 	}
 }
 
@@ -1118,7 +1269,9 @@ func (s *S) TestAugment(c *check.C) {
 		var s Dense
 		s.Augment(a, b)
 
-		c.Check(Equal(&s, NewDense(flatten(test.e))), check.Equals, true, check.Commentf("Test %d: %v stack %v = %v", i, a, b, s))
+		if !Equal(&s, NewDense(flatten(test.e))) {
+			c.Errorf("unexpected result for Augment test %d: %v augment %v = %v", i, a, b, s)
+		}
 	}
 }
 
@@ -1189,10 +1342,14 @@ func (s *S) TestRankOne(c *check.C) {
 		m := &Dense{}
 		// Check with a new matrix
 		m.RankOne(a, test.alpha, NewVector(len(test.x), test.x), NewVector(len(test.y), test.y))
-		c.Check(Equal(m, want), check.Equals, true, check.Commentf("Test %v. Want %v, Got %v", i, want, m))
+		if !Equal(m, want) {
+			c.Errorf("unexpected result for RankOne test %d iteration 0: got: %+v want: %+v", i, m, want)
+		}
 		// Check with the same matrix
 		a.RankOne(a, test.alpha, NewVector(len(test.x), test.x), NewVector(len(test.y), test.y))
-		c.Check(Equal(a, want), check.Equals, true, check.Commentf("Test %v. Want %v, Got %v", i, want, m))
+		if !Equal(a, want) {
+			c.Errorf("unexpected result for Outer test %d iteration 1: got: %+v want: %+v", i, m, want)
+		}
 	}
 }
 
@@ -1234,12 +1391,13 @@ func (s *S) TestOuter(c *check.C) {
 		want.Mul(xm, ym)
 
 		var m Dense
-		// Check with a new matrix
-		m.Outer(NewVector(len(test.x), test.x), NewVector(len(test.y), test.y))
-		c.Check(Equal(&m, want), check.Equals, true, check.Commentf("Test %v. Want %v, Got %v", i, want, m))
-		// Check with the same matrix
-		m.Outer(NewVector(len(test.x), test.x), NewVector(len(test.y), test.y))
-		c.Check(Equal(&m, want), check.Equals, true, check.Commentf("Test %v. Want %v, Got %v", i, want, m))
+		for j := 0; j < 2; j++ {
+			// Check with a new matrix - and then again.
+			m.Outer(NewVector(len(test.x), test.x), NewVector(len(test.y), test.y))
+			if !Equal(&m, want) {
+				c.Errorf("unexpected result for Outer test %d iteration %d: got: %+v want: %+v", i, j, m, want)
+			}
+		}
 	}
 }
 

--- a/mat64/eigen_test.go
+++ b/mat64/eigen_test.go
@@ -7,11 +7,10 @@ package mat64
 import (
 	"math"
 	"reflect"
-
-	"gopkg.in/check.v1"
+	"testing"
 )
 
-func (s *S) TestEigen(c *check.C) {
+func TestEigen(t *testing.T) {
 	for i, test := range []struct {
 		a *Dense
 
@@ -88,25 +87,25 @@ func (s *S) TestEigen(c *check.C) {
 		ef := Eigen(DenseCopyOf(test.a), test.epsilon)
 		if test.d != nil {
 			if !reflect.DeepEqual(ef.d, test.d) {
-				c.Errorf("unexpected d for test %d", i)
+				t.Errorf("unexpected d for test %d", i)
 			}
 		}
 		if test.e != nil {
 			if !reflect.DeepEqual(ef.e, test.e) {
-				c.Errorf("unexpected e for test %d", i)
+				t.Errorf("unexpected e for test %d", i)
 			}
 		}
 
 		if test.v != nil {
 			if !Equal(ef.V, test.v) {
-				c.Errorf("unexpected v for test %d", i)
+				t.Errorf("unexpected v for test %d", i)
 			}
 		}
 
 		test.a.Mul(test.a, ef.V)
 		ef.V.Mul(ef.V, ef.D())
 		if !EqualApprox(test.a, ef.V, 1e-12) {
-			c.Errorf("unexpected factor product for test %d", i)
+			t.Errorf("unexpected factor product for test %d", i)
 		}
 	}
 }

--- a/mat64/format_test.go
+++ b/mat64/format_test.go
@@ -7,11 +7,10 @@ package mat64
 import (
 	"fmt"
 	"math"
-
-	"gopkg.in/check.v1"
+	"testing"
 )
 
-func (s *S) TestFormat(c *check.C) {
+func TestFormat(t *testing.T) {
 	type rp struct {
 		format string
 		output string
@@ -144,7 +143,7 @@ func (s *S) TestFormat(c *check.C) {
 		for j, rp := range test.rep {
 			got := fmt.Sprintf(rp.format, test.m)
 			if got != rp.output {
-				c.Errorf("unexpected format result test %d part %d:\ngot:\n%s\nwant:\n%s", i, j, got, rp.output)
+				t.Errorf("unexpected format result test %d part %d:\ngot:\n%s\nwant:\n%s", i, j, got, rp.output)
 			}
 		}
 	}

--- a/mat64/inner_test.go
+++ b/mat64/inner_test.go
@@ -9,10 +9,9 @@ import (
 	"testing"
 
 	"github.com/gonum/blas/blas64"
-	"gopkg.in/check.v1"
 )
 
-func (s *S) TestInner(c *check.C) {
+func TestInner(t *testing.T) {
 	for i, test := range []struct {
 		x []float64
 		y []float64
@@ -76,22 +75,22 @@ func (s *S) TestInner(c *check.C) {
 
 			rm, cm := cell.Dims()
 			if rm != 1 {
-				c.Errorf("Test %d result doesn't have 1 row", i)
+				t.Errorf("Test %d result doesn't have 1 row", i)
 			}
 			if cm != 1 {
-				c.Errorf("Test %d result doesn't have 1 column", i)
+				t.Errorf("Test %d result doesn't have 1 column", i)
 			}
 
 			want := cell.At(0, 0)
 			got := Inner(makeVectorInc(inc.x, test.x), m, makeVectorInc(inc.y, test.y))
 			if got != want {
-				c.Errorf("Test %v: want %v, got %v", i, want, got)
+				t.Errorf("Test %v: want %v, got %v", i, want, got)
 			}
 		}
 	}
 }
 
-func (s *S) TestInnerSym(c *check.C) {
+func TestInnerSym(t *testing.T) {
 	for _, inc := range []struct{ x, y int }{
 		{1, 1},
 		{1, 2},
@@ -123,7 +122,7 @@ func (s *S) TestInnerSym(c *check.C) {
 		}
 
 		if math.Abs(Inner(x, sym, y)-ans) > 1e-14 {
-			c.Error("inner different symmetric and dense")
+			t.Error("inner different symmetric and dense")
 		}
 	}
 }

--- a/mat64/io_test.go
+++ b/mat64/io_test.go
@@ -4,11 +4,9 @@
 
 package mat64
 
-import (
-	"gopkg.in/check.v1"
-)
+import "testing"
 
-func (s *S) TestDenseRW(c *check.C) {
+func TestDenseRW(t *testing.T) {
 	for i, test := range []*Dense{
 		NewDense(0, 0, []float64{}),
 		NewDense(2, 2, []float64{1, 2, 3, 4}),
@@ -21,23 +19,23 @@ func (s *S) TestDenseRW(c *check.C) {
 	} {
 		buf, err := test.MarshalBinary()
 		if err != nil {
-			c.Errorf("error encoding test #%d: %v\n", i, err)
+			t.Errorf("error encoding test #%d: %v\n", i, err)
 		}
 
 		nrows, ncols := test.Dims()
 		sz := nrows*ncols*sizeFloat64 + 2*sizeInt64
 		if len(buf) != sz {
-			c.Errorf("encoded size test #%d: want=%d got=%d\n", i, sz, len(buf))
+			t.Errorf("encoded size test #%d: want=%d got=%d\n", i, sz, len(buf))
 		}
 
 		var got Dense
 		err = got.UnmarshalBinary(buf)
 		if err != nil {
-			c.Errorf("error decoding test #%d: %v\n", i, err)
+			t.Errorf("error decoding test #%d: %v\n", i, err)
 		}
 
 		if !Equal(&got, test) {
-			c.Errorf("r/w test #%d failed\nwant=%#v\n got=%#v\n", i, test, &got)
+			t.Errorf("r/w test #%d failed\nwant=%#v\n got=%#v\n", i, test, &got)
 		}
 	}
 }

--- a/mat64/list_test.go
+++ b/mat64/list_test.go
@@ -9,10 +9,10 @@ import (
 	"math"
 	"math/rand"
 	"reflect"
+	"testing"
 
 	"github.com/gonum/blas/blas64"
 	"github.com/gonum/floats"
-	"gopkg.in/check.v1"
 )
 
 // legalSizeSameRectangular returns whether the two matrices have the same rectangular shape.
@@ -456,7 +456,7 @@ var testMatrices = []Matrix{
 	Transpose{&basicTriangular{}},
 }
 
-func testOneInputFunc(c *check.C,
+func testOneInputFunc(t *testing.T,
 	// name is the name of the function being tested.
 	name string,
 
@@ -518,27 +518,27 @@ func testOneInputFunc(c *check.C,
 			var got interface{}
 			panicked, err := panics(func() { got = f(a) })
 			if !dimsOK && !panicked {
-				c.Errorf("Did not panic with illegal size: %s", errStr)
+				t.Errorf("Did not panic with illegal size: %s", errStr)
 				continue
 			}
 			if dimsOK && panicked {
-				c.Errorf("Panicked with legal size: %s %s", errStr, err)
+				t.Errorf("Panicked with legal size: %s %s", errStr, err)
 				continue
 			}
 			if !equal(a, aCopy) {
-				c.Errorf("First input argument changed in call: %s", errStr)
+				t.Errorf("First input argument changed in call: %s", errStr)
 			}
 			if !dimsOK {
 				continue
 			}
 			if !sameAnswer(want, got) {
-				c.Errorf("Answer mismatch: %s", errStr)
+				t.Errorf("Answer mismatch: %s", errStr)
 			}
 		}
 	}
 }
 
-func testTwoInputFunc(c *check.C,
+func testTwoInputFunc(t *testing.T,
 	// name is the name of the function being tested.
 	name string,
 
@@ -684,24 +684,24 @@ func testTwoInputFunc(c *check.C,
 				var got interface{}
 				panicked, err := panics(func() { got = f(a, b) })
 				if !dimsOK && !panicked {
-					c.Errorf("Did not panic with illegal size: %s", errStr)
+					t.Errorf("Did not panic with illegal size: %s", errStr)
 					continue
 				}
 				if dimsOK && panicked {
-					c.Errorf("Panicked with legal size: %s %s", errStr, err)
+					t.Errorf("Panicked with legal size: %s %s", errStr, err)
 					continue
 				}
 				if !equal(a, aCopy) {
-					c.Errorf("First input argument changed in call: %s", errStr)
+					t.Errorf("First input argument changed in call: %s", errStr)
 				}
 				if !equal(b, bCopy) {
-					c.Errorf("First input argument changed in call: %s", errStr)
+					t.Errorf("First input argument changed in call: %s", errStr)
 				}
 				if !dimsOK {
 					continue
 				}
 				if !sameAnswer(want, got) {
-					c.Errorf("Answer mismatch: %s", errStr)
+					t.Errorf("Answer mismatch: %s", errStr)
 				}
 			}
 		}
@@ -709,7 +709,7 @@ func testTwoInputFunc(c *check.C,
 }
 
 // testOneInput tests a method that has one matrix input argument
-func testOneInput(c *check.C,
+func testOneInput(t *testing.T,
 	// name is the name of the method being tested.
 	name string,
 
@@ -772,21 +772,21 @@ func testOneInput(c *check.C,
 			zero := makeRandOf(receiver, 0, 0)
 			panicked, err := panics(func() { method(zero, a) })
 			if !dimsOK && !panicked {
-				c.Errorf("Did not panic with illegal size: %s", errStr)
+				t.Errorf("Did not panic with illegal size: %s", errStr)
 				continue
 			}
 			if dimsOK && panicked {
-				c.Errorf("Panicked with legal size: %s %s", errStr, err)
+				t.Errorf("Panicked with legal size: %s %s", errStr, err)
 				continue
 			}
 			if !equal(a, aCopy) {
-				c.Errorf("First input argument changed in call: %s", errStr)
+				t.Errorf("First input argument changed in call: %s", errStr)
 			}
 			if !dimsOK {
 				continue
 			}
 			if !equalApprox(zero, &want, tol) {
-				c.Errorf("Answer mismatch with zero receiver: %s", errStr)
+				t.Errorf("Answer mismatch with zero receiver: %s", errStr)
 				continue
 			}
 
@@ -797,10 +797,10 @@ func testOneInput(c *check.C,
 			nonZero := makeRandOf(receiver, rr, rc)
 			panicked, _ = panics(func() { method(nonZero, a) })
 			if panicked {
-				c.Errorf("Panicked with non-zero receiver: %s", errStr)
+				t.Errorf("Panicked with non-zero receiver: %s", errStr)
 			}
 			if !equalApprox(nonZero, &want, tol) {
-				c.Errorf("Answer mismatch non-zero receiver: %s", errStr)
+				t.Errorf("Answer mismatch non-zero receiver: %s", errStr)
 			}
 
 			// Test with an incorrectly sized matrix.
@@ -811,26 +811,26 @@ func testOneInput(c *check.C,
 				wrongSize := makeRandOf(receiver, rr+1, rc)
 				panicked, _ = panics(func() { method(wrongSize, a) })
 				if !panicked {
-					c.Errorf("Did not panic with wrong number of rows: %s", errStr)
+					t.Errorf("Did not panic with wrong number of rows: %s", errStr)
 				}
 				wrongSize = makeRandOf(receiver, rr, rc+1)
 				panicked, _ = panics(func() { method(wrongSize, a) })
 				if !panicked {
-					c.Errorf("Did not panic with wrong number of columns: %s", errStr)
+					t.Errorf("Did not panic with wrong number of columns: %s", errStr)
 				}
 			case *TriDense, *SymDense:
 				// Add to the square size.
 				wrongSize := makeRandOf(receiver, rr+1, rc+1)
 				panicked, _ = panics(func() { method(wrongSize, a) })
 				if !panicked {
-					c.Errorf("Did not panic with wrong size: %s", errStr)
+					t.Errorf("Did not panic with wrong size: %s", errStr)
 				}
 			case *Vector:
 				// Add to the column length.
 				wrongSize := makeRandOf(receiver, rr+1, rc)
 				panicked, _ = panics(func() { method(wrongSize, a) })
 				if !panicked {
-					c.Errorf("Did not panic with wrong number of rows: %s", errStr)
+					t.Errorf("Did not panic with wrong number of rows: %s", errStr)
 				}
 			}
 
@@ -849,14 +849,14 @@ func testOneInput(c *check.C,
 				preData := underlyingData(receiver)
 				panicked, err = panics(func() { method(receiver, aSame) })
 				if panicked {
-					c.Errorf("Panics when a maybeSame: %s: %s", errStr, err)
+					t.Errorf("Panics when a maybeSame: %s: %s", errStr, err)
 				} else {
 					if !equalApprox(receiver, &want, tol) {
-						c.Errorf("Wrong answer when a maybeSame: %s", errStr)
+						t.Errorf("Wrong answer when a maybeSame: %s", errStr)
 					}
 					postData := underlyingData(receiver)
 					if !floats.Equal(preData, postData) {
-						c.Errorf("Original data slice not modified when a maybeSame: %s", errStr)
+						t.Errorf("Original data slice not modified when a maybeSame: %s", errStr)
 					}
 				}
 			}
@@ -865,7 +865,7 @@ func testOneInput(c *check.C,
 }
 
 // testTwoInput tests a method that has two input arguments.
-func testTwoInput(c *check.C,
+func testTwoInput(t *testing.T,
 	// name is the name of the method being tested.
 	name string,
 
@@ -1012,24 +1012,24 @@ func testTwoInput(c *check.C,
 				zero := makeRandOf(receiver, 0, 0)
 				panicked, err := panics(func() { method(zero, a, b) })
 				if !dimsOK && !panicked {
-					c.Errorf("Did not panic with illegal size: %s", errStr)
+					t.Errorf("Did not panic with illegal size: %s", errStr)
 					continue
 				}
 				if dimsOK && panicked {
-					c.Errorf("Panicked with legal size: %s %s", errStr, err)
+					t.Errorf("Panicked with legal size: %s %s", errStr, err)
 					continue
 				}
 				if !equal(a, aCopy) {
-					c.Errorf("First input argument changed in call: %s", errStr)
+					t.Errorf("First input argument changed in call: %s", errStr)
 				}
 				if !equal(b, bCopy) {
-					c.Errorf("Second input argument changed in call: %s", errStr)
+					t.Errorf("Second input argument changed in call: %s", errStr)
 				}
 				if !dimsOK {
 					continue
 				}
 				if !equalApprox(zero, &want, tol) {
-					c.Errorf("Answer mismatch with zero receiver: %s", errStr)
+					t.Errorf("Answer mismatch with zero receiver: %s", errStr)
 					continue
 				}
 
@@ -1040,10 +1040,10 @@ func testTwoInput(c *check.C,
 				nonZero := makeRandOf(receiver, rr, rc)
 				panicked, _ = panics(func() { method(nonZero, a, b) })
 				if panicked {
-					c.Errorf("Panicked with non-zero receiver: %s", errStr)
+					t.Errorf("Panicked with non-zero receiver: %s", errStr)
 				}
 				if !equalApprox(nonZero, &want, tol) {
-					c.Errorf("Answer mismatch non-zero receiver: %s", errStr)
+					t.Errorf("Answer mismatch non-zero receiver: %s", errStr)
 				}
 
 				// Test with an incorrectly sized matrix.
@@ -1054,26 +1054,26 @@ func testTwoInput(c *check.C,
 					wrongSize := makeRandOf(receiver, rr+1, rc)
 					panicked, _ = panics(func() { method(wrongSize, a, b) })
 					if !panicked {
-						c.Errorf("Did not panic with wrong number of rows: %s", errStr)
+						t.Errorf("Did not panic with wrong number of rows: %s", errStr)
 					}
 					wrongSize = makeRandOf(receiver, rr, rc+1)
 					panicked, _ = panics(func() { method(wrongSize, a, b) })
 					if !panicked {
-						c.Errorf("Did not panic with wrong number of columns: %s", errStr)
+						t.Errorf("Did not panic with wrong number of columns: %s", errStr)
 					}
 				case *TriDense, *SymDense:
 					// Add to the square size.
 					wrongSize := makeRandOf(receiver, rr+1, rc+1)
 					panicked, _ = panics(func() { method(wrongSize, a, b) })
 					if !panicked {
-						c.Errorf("Did not panic with wrong size: %s", errStr)
+						t.Errorf("Did not panic with wrong size: %s", errStr)
 					}
 				case *Vector:
 					// Add to the column length.
 					wrongSize := makeRandOf(receiver, rr+1, rc)
 					panicked, _ = panics(func() { method(wrongSize, a, b) })
 					if !panicked {
-						c.Errorf("Did not panic with wrong number of rows: %s", errStr)
+						t.Errorf("Did not panic with wrong number of rows: %s", errStr)
 					}
 				}
 
@@ -1093,14 +1093,14 @@ func testTwoInput(c *check.C,
 					preData := underlyingData(receiver)
 					panicked, err = panics(func() { method(receiver, aSame, b) })
 					if panicked {
-						c.Errorf("Panics when a maybeSame: %s: %s", errStr, err)
+						t.Errorf("Panics when a maybeSame: %s: %s", errStr, err)
 					} else {
 						if !equalApprox(receiver, &want, tol) {
-							c.Errorf("Wrong answer when a maybeSame: %s", errStr)
+							t.Errorf("Wrong answer when a maybeSame: %s", errStr)
 						}
 						postData := underlyingData(receiver)
 						if !floats.Equal(preData, postData) {
-							c.Errorf("Original data slice not modified when a maybeSame: %s", errStr)
+							t.Errorf("Original data slice not modified when a maybeSame: %s", errStr)
 						}
 					}
 				}
@@ -1114,14 +1114,14 @@ func testTwoInput(c *check.C,
 					preData := underlyingData(receiver)
 					panicked, err = panics(func() { method(receiver, a, bSame) })
 					if panicked {
-						c.Errorf("Panics when b maybeSame: %s", errStr)
+						t.Errorf("Panics when b maybeSame: %s", errStr)
 					} else {
 						if !equalApprox(receiver, &want, tol) {
-							c.Errorf("Wrong answer when b maybeSame: %s: %s", errStr, err)
+							t.Errorf("Wrong answer when b maybeSame: %s: %s", errStr, err)
 						}
 						postData := underlyingData(receiver)
 						if !floats.Equal(preData, postData) {
-							c.Errorf("Original data slice not modified when b maybeSame: %s", errStr)
+							t.Errorf("Original data slice not modified when b maybeSame: %s", errStr)
 						}
 					}
 				}
@@ -1147,14 +1147,14 @@ func testTwoInput(c *check.C,
 					preData := underlyingData(receiver)
 					panicked, err = panics(func() { method(receiver, aSame, bSame) })
 					if panicked {
-						c.Errorf("Panics when both maybeSame: %s: %s", errStr, err)
+						t.Errorf("Panics when both maybeSame: %s: %s", errStr, err)
 					} else {
 						if !equalApprox(receiver, zero, tol) {
-							c.Errorf("Wrong answer when both maybeSame: %s", errStr)
+							t.Errorf("Wrong answer when both maybeSame: %s", errStr)
 						}
 						postData := underlyingData(receiver)
 						if !floats.Equal(preData, postData) {
-							c.Errorf("Original data slice not modified when both maybeSame: %s", errStr)
+							t.Errorf("Original data slice not modified when both maybeSame: %s", errStr)
 						}
 					}
 				}

--- a/mat64/lq_test.go
+++ b/mat64/lq_test.go
@@ -6,11 +6,10 @@ package mat64
 
 import (
 	"math/rand"
-
-	"gopkg.in/check.v1"
+	"testing"
 )
 
-func (s *S) TestLQ(c *check.C) {
+func TestLQ(t *testing.T) {
 	for _, test := range []struct {
 		m, n int
 	}{
@@ -34,7 +33,7 @@ func (s *S) TestLQ(c *check.C) {
 		q.QFromLQ(lq)
 
 		if !isOrthonormal(&q, 1e-10) {
-			c.Errorf("Q is not orthonormal: m = %v, n = %v", m, n)
+			t.Errorf("Q is not orthonormal: m = %v, n = %v", m, n)
 		}
 
 		l.LFromLQ(lq)
@@ -42,12 +41,12 @@ func (s *S) TestLQ(c *check.C) {
 		var got Dense
 		got.Mul(&l, &q)
 		if !EqualApprox(&got, &want, 1e-12) {
-			c.Errorf("LQ does not equal original matrix. \nWant: %v\nGot: %v", want, got)
+			t.Errorf("LQ does not equal original matrix. \nWant: %v\nGot: %v", want, got)
 		}
 	}
 }
 
-func (s *S) TestSolveLQ(c *check.C) {
+func TestSolveLQ(t *testing.T) {
 	for _, trans := range []bool{false, true} {
 		for _, test := range []struct {
 			m, n, bc int
@@ -98,14 +97,14 @@ func (s *S) TestSolveLQ(c *check.C) {
 				rhs.Mul(a.T(), b)
 			}
 			if !EqualApprox(&lhs, &rhs, 1e-10) {
-				c.Errorf("Normal equations do not hold.\nLHS: %v\n, RHS: %v\n", lhs, rhs)
+				t.Errorf("Normal equations do not hold.\nLHS: %v\n, RHS: %v\n", lhs, rhs)
 			}
 		}
 	}
 	// TODO(btracey): Add in testOneInput when it exists.
 }
 
-func (s *S) TestSolveLQVec(c *check.C) {
+func TestSolveLQVec(t *testing.T) {
 	for _, trans := range []bool{false, true} {
 		for _, test := range []struct {
 			m, n int
@@ -151,14 +150,14 @@ func (s *S) TestSolveLQVec(c *check.C) {
 				rhs.Mul(a.T(), b)
 			}
 			if !EqualApprox(&lhs, &rhs, 1e-10) {
-				c.Errorf("Normal equations do not hold.\nLHS: %v\n, RHS: %v\n", lhs, rhs)
+				t.Errorf("Normal equations do not hold.\nLHS: %v\n, RHS: %v\n", lhs, rhs)
 			}
 		}
 	}
 	// TODO(btracey): Add in testOneInput when it exists.
 }
 
-func (s *S) TestSolveLQCond(c *check.C) {
+func TestSolveLQCond(t *testing.T) {
 	for _, test := range []*Dense{
 		NewDense(2, 2, []float64{1, 0, 0, 1e-20}),
 		NewDense(2, 3, []float64{1, 0, 0, 0, 1e-20, 0}),
@@ -169,13 +168,13 @@ func (s *S) TestSolveLQCond(c *check.C) {
 		b := NewDense(m, 2, nil)
 		var x Dense
 		if err := x.SolveLQ(&lq, false, b); err == nil {
-			c.Error("No error for near-singular matrix in matrix solve.")
+			t.Error("No error for near-singular matrix in matrix solve.")
 		}
 
 		bvec := NewVector(m, nil)
 		var xvec Vector
 		if err := xvec.SolveLQVec(&lq, false, bvec); err == nil {
-			c.Error("No error for near-singular matrix in matrix solve.")
+			t.Error("No error for near-singular matrix in matrix solve.")
 		}
 	}
 }

--- a/mat64/lu_test.go
+++ b/mat64/lu_test.go
@@ -6,11 +6,10 @@ package mat64
 
 import (
 	"math/rand"
-
-	"gopkg.in/check.v1"
+	"testing"
 )
 
-func (s *S) TestLUD(c *check.C) {
+func TestLUD(t *testing.T) {
 	for _, n := range []int{1, 5, 10, 11, 50} {
 		a := NewDense(n, n, nil)
 		for i := 0; i < n; i++ {
@@ -34,12 +33,12 @@ func (s *S) TestLUD(c *check.C) {
 		got.Mul(&p, &l)
 		got.Mul(&got, &u)
 		if !EqualApprox(&got, &want, 1e-12) {
-			c.Errorf("PLU does not equal original matrix.\nWant: %v\n Got: %v", want, got)
+			t.Errorf("PLU does not equal original matrix.\nWant: %v\n Got: %v", want, got)
 		}
 	}
 }
 
-func (s *S) TestLURankOne(c *check.C) {
+func TestLURankOne(t *testing.T) {
 	for _, pivoting := range []bool{true} {
 		for _, n := range []int{3, 10, 50} {
 			// Construct a random LU factorization
@@ -82,10 +81,10 @@ func (s *S) TestLURankOne(c *check.C) {
 			aR1 := luReconstruct(lu)
 
 			if !Equal(aR1, aR1New) {
-				c.Error("Different answer when new receiver")
+				t.Error("Different answer when new receiver")
 			}
 			if !EqualApprox(aR1, a, 1e-10) {
-				c.Errorf("Rank one mismatch, pivot %v.\nWant: %v\nGot:%v\n", pivoting, a, aR1)
+				t.Errorf("Rank one mismatch, pivot %v.\nWant: %v\nGot:%v\n", pivoting, a, aR1)
 			}
 		}
 	}
@@ -106,7 +105,7 @@ func luReconstruct(lu *LU) *Dense {
 	return &a
 }
 
-func (s *S) TestSolveLU(c *check.C) {
+func TestSolveLU(t *testing.T) {
 	for _, test := range []struct {
 		n, bc int
 	}{
@@ -137,13 +136,13 @@ func (s *S) TestSolveLU(c *check.C) {
 		var got Dense
 		got.Mul(a, &x)
 		if !EqualApprox(&got, b, 1e-12) {
-			c.Error("Solve mismatch for non-singular matrix. n = %v, bc = %v.\nWant: %v\nGot: %v", n, bc, b, got)
+			t.Error("Solve mismatch for non-singular matrix. n = %v, bc = %v.\nWant: %v\nGot: %v", n, bc, b, got)
 		}
 	}
 	// TODO(btracey): Add testOneInput test when such a function exists.
 }
 
-func (s *S) TestSolveLUCond(c *check.C) {
+func TestSolveLUCond(t *testing.T) {
 	for _, test := range []*Dense{
 		NewDense(2, 2, []float64{1, 0, 0, 1e-20}),
 	} {
@@ -153,18 +152,18 @@ func (s *S) TestSolveLUCond(c *check.C) {
 		b := NewDense(m, 2, nil)
 		var x Dense
 		if err := x.SolveLU(&lu, false, b); err == nil {
-			c.Error("No error for near-singular matrix in matrix solve.")
+			t.Error("No error for near-singular matrix in matrix solve.")
 		}
 
 		bvec := NewVector(m, nil)
 		var xvec Vector
 		if err := xvec.SolveLUVec(&lu, false, bvec); err == nil {
-			c.Error("No error for near-singular matrix in matrix solve.")
+			t.Error("No error for near-singular matrix in matrix solve.")
 		}
 	}
 }
 
-func (s *S) TestSolveLUVec(c *check.C) {
+func TestSolveLUVec(t *testing.T) {
 	for _, n := range []int{5, 10} {
 		a := NewDense(n, n, nil)
 		for i := 0; i < n; i++ {
@@ -185,7 +184,7 @@ func (s *S) TestSolveLUVec(c *check.C) {
 		var got Vector
 		got.MulVec(a, &x)
 		if !EqualApprox(&got, b, 1e-12) {
-			c.Error("Solve mismatch n = %v.\nWant: %v\nGot: %v", n, b, got)
+			t.Error("Solve mismatch n = %v.\nWant: %v\nGot: %v", n, b, got)
 		}
 	}
 	// TODO(btracey): Add testOneInput test when such a function exists.

--- a/mat64/matrix_test.go
+++ b/mat64/matrix_test.go
@@ -8,16 +8,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
-
-	"gopkg.in/check.v1"
 )
-
-// Tests
-func Test(t *testing.T) { check.TestingT(t) }
-
-type S struct{}
-
-var _ = check.Suite(&S{})
 
 func leaksPanic(fn func()) (panicked bool) {
 	defer func() {
@@ -70,7 +61,7 @@ func eye() *Dense {
 	})
 }
 
-func (s *S) TestCol(c *check.C) {
+func TestCol(t *testing.T) {
 	f := func(a Matrix) interface{} {
 		_, c := a.Dims()
 		ans := make([][]float64, c)
@@ -87,7 +78,7 @@ func (s *S) TestCol(c *check.C) {
 		}
 		return ans
 	}
-	testOneInputFunc(c, "Col", f, denseComparison, sameAnswerF64SliceOfSlice, isAnyType, isAnySize)
+	testOneInputFunc(t, "Col", f, denseComparison, sameAnswerF64SliceOfSlice, isAnyType, isAnySize)
 	f = func(a Matrix) interface{} {
 		r, c := a.Dims()
 		ans := make([][]float64, c)
@@ -97,10 +88,10 @@ func (s *S) TestCol(c *check.C) {
 		}
 		return ans
 	}
-	testOneInputFunc(c, "Col", f, denseComparison, sameAnswerF64SliceOfSlice, isAnyType, isAnySize)
+	testOneInputFunc(t, "Col", f, denseComparison, sameAnswerF64SliceOfSlice, isAnyType, isAnySize)
 }
 
-func (s *S) TestRow(c *check.C) {
+func TestRow(t *testing.T) {
 	f := func(a Matrix) interface{} {
 		r, _ := a.Dims()
 		ans := make([][]float64, r)
@@ -117,7 +108,7 @@ func (s *S) TestRow(c *check.C) {
 		}
 		return ans
 	}
-	testOneInputFunc(c, "Row", f, denseComparison, sameAnswerF64SliceOfSlice, isAnyType, isAnySize)
+	testOneInputFunc(t, "Row", f, denseComparison, sameAnswerF64SliceOfSlice, isAnyType, isAnySize)
 	f = func(a Matrix) interface{} {
 		r, c := a.Dims()
 		ans := make([][]float64, r)
@@ -127,30 +118,30 @@ func (s *S) TestRow(c *check.C) {
 		}
 		return ans
 	}
-	testOneInputFunc(c, "Row", f, denseComparison, sameAnswerF64SliceOfSlice, isAnyType, isAnySize)
+	testOneInputFunc(t, "Row", f, denseComparison, sameAnswerF64SliceOfSlice, isAnyType, isAnySize)
 }
 
-func (s *S) TestDot(c *check.C) {
+func TestDot(t *testing.T) {
 	f := func(a, b Matrix) interface{} {
 		return Dot(a, b)
 	}
 	denseComparison := func(a, b *Dense) interface{} {
 		return Dot(a, b)
 	}
-	testTwoInputFunc(c, "Dot", f, denseComparison, sameAnswerFloatApprox, legalTypesAll, legalSizeSameRectangular)
+	testTwoInputFunc(t, "Dot", f, denseComparison, sameAnswerFloatApprox, legalTypesAll, legalSizeSameRectangular)
 }
 
-func (s *S) TestEqual(c *check.C) {
+func TestEqual(t *testing.T) {
 	f := func(a, b Matrix) interface{} {
 		return Equal(a, b)
 	}
 	denseComparison := func(a, b *Dense) interface{} {
 		return Equal(a, b)
 	}
-	testTwoInputFunc(c, "Equal", f, denseComparison, sameAnswerBool, legalTypesAll, isAnySize2)
+	testTwoInputFunc(t, "Equal", f, denseComparison, sameAnswerBool, legalTypesAll, isAnySize2)
 }
 
-func (s *S) TestMax(c *check.C) {
+func TestMax(t *testing.T) {
 	// A direct test of Max with *Dense arguments is in TestNewDense.
 	f := func(a Matrix) interface{} {
 		return Max(a)
@@ -158,10 +149,10 @@ func (s *S) TestMax(c *check.C) {
 	denseComparison := func(a *Dense) interface{} {
 		return Max(a)
 	}
-	testOneInputFunc(c, "Max", f, denseComparison, sameAnswerFloat, isAnyType, isAnySize)
+	testOneInputFunc(t, "Max", f, denseComparison, sameAnswerFloat, isAnyType, isAnySize)
 }
 
-func (s *S) TestMin(c *check.C) {
+func TestMin(t *testing.T) {
 	// A direct test of Min with *Dense arguments is in TestNewDense.
 	f := func(a Matrix) interface{} {
 		return Min(a)
@@ -169,10 +160,10 @@ func (s *S) TestMin(c *check.C) {
 	denseComparison := func(a *Dense) interface{} {
 		return Min(a)
 	}
-	testOneInputFunc(c, "Min", f, denseComparison, sameAnswerFloat, isAnyType, isAnySize)
+	testOneInputFunc(t, "Min", f, denseComparison, sameAnswerFloat, isAnyType, isAnySize)
 }
 
-func (s *S) TestMaybe(c *check.C) {
+func TestMaybe(t *testing.T) {
 	for i, test := range []struct {
 		fn     func()
 		panics bool
@@ -191,13 +182,13 @@ func (s *S) TestMaybe(c *check.C) {
 		},
 	} {
 		if panicked := leaksPanic(test.fn); panicked != test.panics {
-			c.Errorf("unexpected panic state for test %d: got: panicked=%t want panicked=%t",
+			t.Errorf("unexpected panic state for test %d: got: panicked=%t want panicked=%t",
 				i, panicked, test.panics)
 		}
 	}
 }
 
-func (s *S) TestNorm(c *check.C) {
+func TestNorm(t *testing.T) {
 	for i, test := range []struct {
 		a    [][]float64
 		ord  float64
@@ -231,7 +222,7 @@ func (s *S) TestNorm(c *check.C) {
 	} {
 		a := NewDense(flatten(test.a))
 		if math.Abs(Norm(a, test.ord)-test.norm) > 1e-14 {
-			c.Errorf("Mismatch test %d: %v norm = %f", i, test.a, test.norm)
+			t.Errorf("Mismatch test %d: %v norm = %f", i, test.a, test.norm)
 		}
 	}
 
@@ -241,7 +232,7 @@ func (s *S) TestNorm(c *check.C) {
 	denseComparison := func(a *Dense) interface{} {
 		return Norm(a, 1)
 	}
-	testOneInputFunc(c, "Norm_1", f, denseComparison, sameAnswerFloatApprox, isAnyType, isAnySize)
+	testOneInputFunc(t, "Norm_1", f, denseComparison, sameAnswerFloatApprox, isAnyType, isAnySize)
 
 	f = func(a Matrix) interface{} {
 		return Norm(a, 2)
@@ -249,7 +240,7 @@ func (s *S) TestNorm(c *check.C) {
 	denseComparison = func(a *Dense) interface{} {
 		return Norm(a, 2)
 	}
-	testOneInputFunc(c, "Norm_2", f, denseComparison, sameAnswerFloatApprox, isAnyType, isAnySize)
+	testOneInputFunc(t, "Norm_2", f, denseComparison, sameAnswerFloatApprox, isAnyType, isAnySize)
 
 	f = func(a Matrix) interface{} {
 		return Norm(a, math.Inf(1))
@@ -257,20 +248,20 @@ func (s *S) TestNorm(c *check.C) {
 	denseComparison = func(a *Dense) interface{} {
 		return Norm(a, math.Inf(1))
 	}
-	testOneInputFunc(c, "Norm_inf", f, denseComparison, sameAnswerFloatApprox, isAnyType, isAnySize)
+	testOneInputFunc(t, "Norm_inf", f, denseComparison, sameAnswerFloatApprox, isAnyType, isAnySize)
 }
 
-func (s *S) TestSum(c *check.C) {
+func TestSum(t *testing.T) {
 	f := func(a Matrix) interface{} {
 		return Sum(a)
 	}
 	denseComparison := func(a *Dense) interface{} {
 		return Sum(a)
 	}
-	testOneInputFunc(c, "Sum", f, denseComparison, sameAnswerFloatApprox, isAnyType, isAnySize)
+	testOneInputFunc(t, "Sum", f, denseComparison, sameAnswerFloatApprox, isAnyType, isAnySize)
 }
 
-func (s *S) TestTrace(c *check.C) {
+func TestTrace(t *testing.T) {
 	for _, test := range []struct {
 		a     *Dense
 		trace float64
@@ -282,7 +273,7 @@ func (s *S) TestTrace(c *check.C) {
 	} {
 		trace := Trace(test.a)
 		if trace != test.trace {
-			c.Errorf("Trace mismatch. Want %v, got %v", test.trace, trace)
+			t.Errorf("Trace mismatch. Want %v, got %v", test.trace, trace)
 		}
 	}
 	f := func(a Matrix) interface{} {
@@ -291,5 +282,5 @@ func (s *S) TestTrace(c *check.C) {
 	denseComparison := func(a *Dense) interface{} {
 		return Trace(a)
 	}
-	testOneInputFunc(c, "Trace", f, denseComparison, sameAnswerFloat, isAnyType, isSquare)
+	testOneInputFunc(t, "Trace", f, denseComparison, sameAnswerFloat, isAnyType, isSquare)
 }

--- a/mat64/mul_test.go
+++ b/mat64/mul_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // TODO: Need to add tests where one is overwritten.
-func TestMul(t *testing.T) {
+func TestMulTypes(t *testing.T) {
 	for _, test := range []struct {
 		ar     int
 		ac     int
@@ -166,6 +166,7 @@ func TestMul(t *testing.T) {
 		testMul(t, am, bm, d, acomp, bcomp, ccomp, true, "both basic, receiver is full")
 	}
 }
+
 func randomSlice(s []float64) {
 	for i := range s {
 		s[i] = rand.NormFloat64()

--- a/mat64/pool_test.go
+++ b/mat64/pool_test.go
@@ -9,11 +9,9 @@ import (
 	"math/rand"
 	"reflect"
 	"testing"
-
-	"gopkg.in/check.v1"
 )
 
-func (s *S) TestPool(c *check.C) {
+func TestPool(t *testing.T) {
 	for i := 1; i < 10; i++ {
 		for j := 1; j < 10; j++ {
 			m := NewDense(i, j, nil)
@@ -22,16 +20,16 @@ func (s *S) TestPool(c *check.C) {
 				for l := range work {
 					w := getWorkspace(i, j, true)
 					if !reflect.DeepEqual(w.mat, m.mat) {
-						c.Error("unexpected non-zeroed matrix returned by getWorkspace")
+						t.Error("unexpected non-zeroed matrix returned by getWorkspace")
 					}
 					if w.capRows != m.capRows {
-						c.Error("unexpected capacity matrix returned by getWorkspace")
+						t.Error("unexpected capacity matrix returned by getWorkspace")
 					}
 					if w.capCols != m.capCols {
-						c.Error("unexpected capacity matrix returned by getWorkspace")
+						t.Error("unexpected capacity matrix returned by getWorkspace")
 					}
 					if cap(w.mat.Data) >= 2*len(w.mat.Data) {
-						c.Errorf("r: %d c: %d -> len: %d cap: %d", i, j, len(w.mat.Data), cap(w.mat.Data))
+						t.Errorf("r: %d c: %d -> len: %d cap: %d", i, j, len(w.mat.Data), cap(w.mat.Data))
 					}
 					w.Set(0, 0, math.NaN())
 					work[l] = w

--- a/mat64/product_test.go
+++ b/mat64/product_test.go
@@ -7,8 +7,7 @@ package mat64
 import (
 	"fmt"
 	"math/rand"
-
-	"gopkg.in/check.v1"
+	"testing"
 )
 
 type dims struct{ r, c int }
@@ -90,7 +89,7 @@ var productTests = []struct {
 	},
 }
 
-func (s *S) TestProduct(c *check.C) {
+func TestProduct(t *testing.T) {
 	for _, test := range productTests {
 		dimensions := test.factors
 		if dimensions == nil && test.n > 0 {
@@ -132,12 +131,12 @@ func (s *S) TestProduct(c *check.C) {
 		})
 		if test.panics {
 			if !panicked {
-				c.Errorf("fail to panic with product chain dimensions: %+v result dimension: %+v",
+				t.Errorf("fail to panic with product chain dimensions: %+v result dimension: %+v",
 					dimensions, test.product)
 			}
 			continue
 		} else if panicked {
-			c.Errorf("unexpected panic %q with product chain dimensions: %+v result dimension: %+v",
+			t.Errorf("unexpected panic %q with product chain dimensions: %+v result dimension: %+v",
 				message, dimensions, test.product)
 			continue
 		}
@@ -148,16 +147,16 @@ func (s *S) TestProduct(c *check.C) {
 			gotCost := p.table.at(0, len(factors)-1).cost
 			expr, wantCost, ok := bestExpressionFor(dimensions)
 			if !ok {
-				c.Fatal("unexpected number of expressions in brute force expression search")
+				t.Fatal("unexpected number of expressions in brute force expression search")
 			}
 			if gotCost != wantCost {
-				c.Errorf("unexpected cost for chain dimensions: %+v got: %d want: %d\n%s",
+				t.Errorf("unexpected cost for chain dimensions: %+v got: %d want: %d\n%s",
 					dimensions, got, want, expr)
 			}
 		}
 
 		if !EqualApprox(got, want, 1e-14) {
-			c.Errorf("unexpected result from product chain dimensions: %+v", dimensions)
+			t.Errorf("unexpected result from product chain dimensions: %+v", dimensions)
 		}
 	}
 }

--- a/mat64/qr_test.go
+++ b/mat64/qr_test.go
@@ -7,12 +7,12 @@ package mat64
 import (
 	"math"
 	"math/rand"
+	"testing"
 
 	"github.com/gonum/blas/blas64"
-	"gopkg.in/check.v1"
 )
 
-func (s *S) TestQR(c *check.C) {
+func TestQR(t *testing.T) {
 	for _, test := range []struct {
 		m, n int
 	}{
@@ -36,7 +36,7 @@ func (s *S) TestQR(c *check.C) {
 		q.QFromQR(qr)
 
 		if !isOrthonormal(&q, 1e-10) {
-			c.Errorf("Q is not orthonormal: m = %v, n = %v", m, n)
+			t.Errorf("Q is not orthonormal: m = %v, n = %v", m, n)
 		}
 
 		r.RFromQR(qr)
@@ -44,7 +44,7 @@ func (s *S) TestQR(c *check.C) {
 		var got Dense
 		got.Mul(&q, &r)
 		if !EqualApprox(&got, &want, 1e-12) {
-			c.Errorf("QR does not equal original matrix. \nWant: %v\nGot: %v", want, got)
+			t.Errorf("QR does not equal original matrix. \nWant: %v\nGot: %v", want, got)
 		}
 	}
 }
@@ -72,7 +72,7 @@ func isOrthonormal(q *Dense, tol float64) bool {
 	return true
 }
 
-func (s *S) TestSolveQR(c *check.C) {
+func TestSolveQR(t *testing.T) {
 	for _, trans := range []bool{false, true} {
 		for _, test := range []struct {
 			m, n, bc int
@@ -123,14 +123,14 @@ func (s *S) TestSolveQR(c *check.C) {
 				rhs.Mul(a.T(), b)
 			}
 			if !EqualApprox(&lhs, &rhs, 1e-10) {
-				c.Errorf("Normal equations do not hold.\nLHS: %v\n, RHS: %v\n", lhs, rhs)
+				t.Errorf("Normal equations do not hold.\nLHS: %v\n, RHS: %v\n", lhs, rhs)
 			}
 		}
 	}
 	// TODO(btracey): Add in testOneInput when it exists.
 }
 
-func (s *S) TestSolveQRVec(c *check.C) {
+func TestSolveQRVec(t *testing.T) {
 	for _, trans := range []bool{false, true} {
 		for _, test := range []struct {
 			m, n int
@@ -176,14 +176,14 @@ func (s *S) TestSolveQRVec(c *check.C) {
 				rhs.Mul(a.T(), b)
 			}
 			if !EqualApprox(&lhs, &rhs, 1e-10) {
-				c.Errorf("Normal equations do not hold.\nLHS: %v\n, RHS: %v\n", lhs, rhs)
+				t.Errorf("Normal equations do not hold.\nLHS: %v\n, RHS: %v\n", lhs, rhs)
 			}
 		}
 	}
 	// TODO(btracey): Add in testOneInput when it exists.
 }
 
-func (s *S) TestSolveQRCond(c *check.C) {
+func TestSolveQRCond(t *testing.T) {
 	for _, test := range []*Dense{
 		NewDense(2, 2, []float64{1, 0, 0, 1e-20}),
 		NewDense(3, 2, []float64{1, 0, 0, 1e-20, 0, 0}),
@@ -194,13 +194,13 @@ func (s *S) TestSolveQRCond(c *check.C) {
 		b := NewDense(m, 2, nil)
 		var x Dense
 		if err := x.SolveQR(&qr, false, b); err == nil {
-			c.Error("No error for near-singular matrix in matrix solve.")
+			t.Error("No error for near-singular matrix in matrix solve.")
 		}
 
 		bvec := NewVector(m, nil)
 		var xvec Vector
 		if err := xvec.SolveQRVec(&qr, false, bvec); err == nil {
-			c.Error("No error for near-singular matrix in matrix solve.")
+			t.Error("No error for near-singular matrix in matrix solve.")
 		}
 	}
 }

--- a/mat64/solve_test.go
+++ b/mat64/solve_test.go
@@ -6,11 +6,10 @@ package mat64
 
 import (
 	"math/rand"
-
-	"gopkg.in/check.v1"
+	"testing"
 )
 
-func (s *S) TestSolve(c *check.C) {
+func TestSolve(t *testing.T) {
 	// Hand-coded cases.
 	for _, test := range []struct {
 		a         [][]float64
@@ -170,16 +169,16 @@ func (s *S) TestSolve(c *check.C) {
 		err := x.Solve(a, b)
 		if err != nil {
 			if !test.shouldErr {
-				c.Errorf("Unexpected solve error: %s", err)
+				t.Errorf("Unexpected solve error: %s", err)
 			}
 			continue
 		}
 		if err == nil && test.shouldErr {
-			c.Errorf("Did not error during solve.")
+			t.Errorf("Did not error during solve.")
 			continue
 		}
 		if !EqualApprox(&x, ans, 1e-12) {
-			c.Errorf("Solve answer mismatch. Want %v, got %v", ans, x)
+			t.Errorf("Solve answer mismatch. Want %v, got %v", ans, x)
 		}
 	}
 
@@ -223,7 +222,7 @@ func (s *S) TestSolve(c *check.C) {
 		lhs.Mul(&tmp, &x)
 		rhs.Mul(a.T(), b)
 		if !EqualApprox(&lhs, &rhs, 1e-10) {
-			c.Errorf("Normal equations do not hold.\nLHS: %v\n, RHS: %v\n", lhs, rhs)
+			t.Errorf("Normal equations do not hold.\nLHS: %v\n, RHS: %v\n", lhs, rhs)
 		}
 	}
 
@@ -238,10 +237,10 @@ func (s *S) TestSolve(c *check.C) {
 	denseComparison := func(receiver, a, b *Dense) {
 		receiver.Solve(a, b)
 	}
-	testTwoInput(c, "Solve", &Dense{}, method, denseComparison, legalTypesAll, legalSizeSolve, 1e-7)
+	testTwoInput(t, "Solve", &Dense{}, method, denseComparison, legalTypesAll, legalSizeSolve, 1e-7)
 }
 
-func (s *S) TestSolveVec(c *check.C) {
+func TestSolveVec(t *testing.T) {
 	for _, test := range []struct {
 		m, n int
 	}{
@@ -278,7 +277,7 @@ func (s *S) TestSolveVec(c *check.C) {
 		lhs.Mul(&tmp, &x)
 		rhs.Mul(a.T(), b)
 		if !EqualApprox(&lhs, &rhs, 1e-10) {
-			c.Errorf("Normal equations do not hold.\nLHS: %v\n, RHS: %v\n", lhs, rhs)
+			t.Errorf("Normal equations do not hold.\nLHS: %v\n, RHS: %v\n", lhs, rhs)
 		}
 	}
 
@@ -293,5 +292,5 @@ func (s *S) TestSolveVec(c *check.C) {
 	denseComparison := func(receiver, a, b *Dense) {
 		receiver.Solve(a, b)
 	}
-	testTwoInput(c, "Solve", &Vector{}, method, denseComparison, legalTypesNotVecVec, legalSizeSolve, 1e-12)
+	testTwoInput(t, "Solve", &Vector{}, method, denseComparison, legalTypesNotVecVec, legalSizeSolve, 1e-12)
 }

--- a/mat64/svd_test.go
+++ b/mat64/svd_test.go
@@ -7,11 +7,10 @@ package mat64
 import (
 	"math"
 	"reflect"
-
-	"gopkg.in/check.v1"
+	"testing"
 )
 
-func (s *S) TestSVD(c *check.C) {
+func TestSVD(t *testing.T) {
 	for i, test := range []struct {
 		a *Dense
 
@@ -174,38 +173,38 @@ func (s *S) TestSVD(c *check.C) {
 		svd := SVD(DenseCopyOf(test.a), test.epsilon, test.small, test.wantu, test.wantv)
 		if test.sigma != nil {
 			if !reflect.DeepEqual(svd.Sigma, test.sigma) {
-				c.Errorf("unexpected sigma for test %d: got: %v want: %v", i, svd.Sigma, test.sigma)
+				t.Errorf("unexpected sigma for test %d: got: %v want: %v", i, svd.Sigma, test.sigma)
 			}
 		}
 		s := svd.S()
 
 		if svd.U != nil {
 			if !Equal(svd.U, test.u) {
-				c.Errorf("unexpected U value for test %d", i)
+				t.Errorf("unexpected U value for test %d", i)
 			}
 		} else if test.wantu || test.u != nil {
-			c.Errorf("unexpectedly did not get U for test %d", i)
+			t.Errorf("unexpectedly did not get U for test %d", i)
 		}
 		if svd.V != nil {
 			if !Equal(svd.V, test.v) {
-				c.Error("unexpected V value")
+				t.Error("unexpected V value")
 			}
 		} else if test.wantv || test.v != nil {
-			c.Errorf("unexpectedly did not get V for test %d", i)
+			t.Errorf("unexpectedly did not get V for test %d", i)
 		}
 
 		if test.wantu && test.wantv {
 			if svd.U == nil {
-				c.Fatalf("unexpect nil U for test %d", i)
+				t.Fatalf("unexpect nil U for test %d", i)
 			}
 			if svd.V == nil {
-				c.Fatalf("unexpect nil V for test %d", i)
+				t.Fatalf("unexpect nil V for test %d", i)
 			}
 			var tmp, got Dense
 			tmp.Mul(svd.U, s)
 			got.Mul(&tmp, svd.V.T())
 			if !EqualApprox(&got, test.a, 1e-12) {
-				c.Errorf("incorrect SVD factor product for test %d", i)
+				t.Errorf("incorrect SVD factor product for test %d", i)
 			}
 		}
 	}

--- a/mat64/triangular_test.go
+++ b/mat64/triangular_test.go
@@ -4,13 +4,13 @@ import (
 	"math"
 	"math/rand"
 	"reflect"
+	"testing"
 
 	"github.com/gonum/blas"
 	"github.com/gonum/blas/blas64"
-	"gopkg.in/check.v1"
 )
 
-func (s *S) TestNewTriangular(c *check.C) {
+func TestNewTriangular(t *testing.T) {
 	for i, test := range []struct {
 		data  []float64
 		n     int
@@ -38,25 +38,25 @@ func (s *S) TestNewTriangular(c *check.C) {
 		rows, cols := tri.Dims()
 
 		if rows != test.n {
-			c.Errorf("unexpected number of rows for test %d: got: %d want: %d", i, rows, test.n)
+			t.Errorf("unexpected number of rows for test %d: got: %d want: %d", i, rows, test.n)
 		}
 		if cols != test.n {
-			c.Errorf("unexpected number of cols for test %d: got: %d want: %d", i, cols, test.n)
+			t.Errorf("unexpected number of cols for test %d: got: %d want: %d", i, cols, test.n)
 		}
 		if !reflect.DeepEqual(tri, test.mat) {
-			c.Errorf("unexpected data slice for test %d: got: %v want: %v", i, tri, test.mat)
+			t.Errorf("unexpected data slice for test %d: got: %v want: %v", i, tri, test.mat)
 		}
 	}
 
 	for _, upper := range []bool{false, true} {
 		panicked, message := panics(func() { NewTriDense(3, upper, []float64{1, 2}) })
 		if !panicked || message != ErrShape.Error() {
-			c.Errorf("expected panic for invalid data slice length for upper=%t", upper)
+			t.Errorf("expected panic for invalid data slice length for upper=%t", upper)
 		}
 	}
 }
 
-func (s *S) TestTriAtSet(c *check.C) {
+func TestTriAtSet(t *testing.T) {
 	tri := &TriDense{blas64.Triangular{
 		N:      3,
 		Stride: 3,
@@ -71,13 +71,13 @@ func (s *S) TestTriAtSet(c *check.C) {
 	for _, row := range []int{-1, rows, rows + 1} {
 		panicked, message := panics(func() { tri.At(row, 0) })
 		if !panicked || message != ErrRowAccess.Error() {
-			c.Errorf("expected panic for invalid row access N=%d r=%d", rows, row)
+			t.Errorf("expected panic for invalid row access N=%d r=%d", rows, row)
 		}
 	}
 	for _, col := range []int{-1, cols, cols + 1} {
 		panicked, message := panics(func() { tri.At(0, col) })
 		if !panicked || message != ErrColAccess.Error() {
-			c.Errorf("expected panic for invalid column access N=%d c=%d", cols, col)
+			t.Errorf("expected panic for invalid column access N=%d c=%d", cols, col)
 		}
 	}
 
@@ -85,13 +85,13 @@ func (s *S) TestTriAtSet(c *check.C) {
 	for _, row := range []int{-1, rows, rows + 1} {
 		panicked, message := panics(func() { tri.SetTri(row, 0, 1.2) })
 		if !panicked || message != ErrRowAccess.Error() {
-			c.Errorf("expected panic for invalid row access N=%d r=%d", rows, row)
+			t.Errorf("expected panic for invalid row access N=%d r=%d", rows, row)
 		}
 	}
 	for _, col := range []int{-1, cols, cols + 1} {
 		panicked, message := panics(func() { tri.SetTri(0, col, 1.2) })
 		if !panicked || message != ErrColAccess.Error() {
-			c.Errorf("expected panic for invalid column access N=%d c=%d", cols, col)
+			t.Errorf("expected panic for invalid column access N=%d c=%d", cols, col)
 		}
 	}
 
@@ -105,7 +105,7 @@ func (s *S) TestTriAtSet(c *check.C) {
 		tri.mat.Uplo = st.uplo
 		panicked, message := panics(func() { tri.SetTri(st.row, st.col, 1.2) })
 		if !panicked || message != ErrTriangleSet.Error() {
-			c.Errorf("expected panic for %+v", st)
+			t.Errorf("expected panic for %+v", st)
 		}
 	}
 
@@ -119,27 +119,27 @@ func (s *S) TestTriAtSet(c *check.C) {
 	} {
 		tri.mat.Uplo = st.uplo
 		if e := tri.At(st.row, st.col); e != st.orig {
-			c.Errorf("unexpected value for At(%d, %d): got: %v want: %v", st.row, st.col, e, st.orig)
+			t.Errorf("unexpected value for At(%d, %d): got: %v want: %v", st.row, st.col, e, st.orig)
 		}
 		tri.SetTri(st.row, st.col, st.new)
 		if e := tri.At(st.row, st.col); e != st.new {
-			c.Errorf("unexpected value for At(%d, %d) after SetTri(%[1]d, %d, %v): got: %v want: %[3]v", st.row, st.col, st.new, e)
+			t.Errorf("unexpected value for At(%d, %d) after SetTri(%[1]d, %d, %v): got: %v want: %[3]v", st.row, st.col, st.new, e)
 		}
 	}
 }
 
-func (s *S) TestTriDenseCopy(c *check.C) {
+func TestTriDenseCopy(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		size := rand.Intn(100)
 		r, err := randDense(size, 0.9, rand.NormFloat64)
 		if size == 0 {
 			if err != ErrZeroLength {
-				c.Fatalf("expected error %v: got: %v", ErrZeroLength, err)
+				t.Fatalf("expected error %v: got: %v", ErrZeroLength, err)
 			}
 			continue
 		}
 		if err != nil {
-			c.Fatalf("unexpected error: %v", err)
+			t.Fatalf("unexpected error: %v", err)
 		}
 
 		u := NewTriDense(size, true, nil)
@@ -158,18 +158,18 @@ func (s *S) TestTriDenseCopy(c *check.C) {
 					switch {
 					case m < n: // Upper triangular matrix.
 						if got := u.At(m, n); got != want {
-							c.Errorf("unexpected upper value for At(%d, %d) for test %d: got: %v want: %v", m, n, i, got, want)
+							t.Errorf("unexpected upper value for At(%d, %d) for test %d: got: %v want: %v", m, n, i, got, want)
 						}
 					case m == n: // Diagonal matrix.
 						if got := u.At(m, n); got != want {
-							c.Errorf("unexpected upper value for At(%d, %d) for test %d: got: %v want: %v", m, n, i, got, want)
+							t.Errorf("unexpected upper value for At(%d, %d) for test %d: got: %v want: %v", m, n, i, got, want)
 						}
 						if got := l.At(m, n); got != want {
-							c.Errorf("unexpected diagonal value for At(%d, %d) for test %d: got: %v want: %v", m, n, i, got, want)
+							t.Errorf("unexpected diagonal value for At(%d, %d) for test %d: got: %v want: %v", m, n, i, got, want)
 						}
 					case m < n: // Lower triangular matrix.
 						if got := l.At(m, n); got != want {
-							c.Errorf("unexpected lower value for At(%d, %d) for test %d: got: %v want: %v", m, n, i, got, want)
+							t.Errorf("unexpected lower value for At(%d, %d) for test %d: got: %v want: %v", m, n, i, got, want)
 						}
 					}
 				}
@@ -178,18 +178,18 @@ func (s *S) TestTriDenseCopy(c *check.C) {
 	}
 }
 
-func (s *S) TestTriTriDenseCopy(c *check.C) {
+func TestTriTriDenseCopy(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		size := rand.Intn(100)
 		r, err := randDense(size, 1, rand.NormFloat64)
 		if size == 0 {
 			if err != ErrZeroLength {
-				c.Fatalf("expected error %v: got: %v", ErrZeroLength, err)
+				t.Fatalf("expected error %v: got: %v", ErrZeroLength, err)
 			}
 			continue
 		}
 		if err != nil {
-			c.Fatalf("unexpected error: %v", err)
+			t.Fatalf("unexpected error: %v", err)
 		}
 
 		ur := NewTriDense(size, true, nil)
@@ -201,31 +201,31 @@ func (s *S) TestTriTriDenseCopy(c *check.C) {
 		u := NewTriDense(size, true, nil)
 		u.Copy(ur)
 		if !equal(u, ur) {
-			c.Fatal("unexpected result for U triangle copy of U triangle: not equal")
+			t.Fatal("unexpected result for U triangle copy of U triangle: not equal")
 		}
 
 		l := NewTriDense(size, false, nil)
 		l.Copy(lr)
 		if !equal(l, lr) {
-			c.Fatal("unexpected result for L triangle copy of L triangle: not equal")
+			t.Fatal("unexpected result for L triangle copy of L triangle: not equal")
 		}
 
 		zero(u.mat.Data)
 		u.Copy(lr)
 		if !isDiagonal(u) {
-			c.Fatal("unexpected result for U triangle copy of L triangle: off diagonal non-zero element")
+			t.Fatal("unexpected result for U triangle copy of L triangle: off diagonal non-zero element")
 		}
 		if !equalDiagonal(u, lr) {
-			c.Fatal("unexpected result for U triangle copy of L triangle: diagonal not equal")
+			t.Fatal("unexpected result for U triangle copy of L triangle: diagonal not equal")
 		}
 
 		zero(l.mat.Data)
 		l.Copy(ur)
 		if !isDiagonal(l) {
-			c.Fatal("unexpected result for L triangle copy of U triangle: off diagonal non-zero element")
+			t.Fatal("unexpected result for L triangle copy of U triangle: off diagonal non-zero element")
 		}
 		if !equalDiagonal(l, ur) {
-			c.Fatal("unexpected result for L triangle copy of U triangle: diagonal not equal")
+			t.Fatal("unexpected result for L triangle copy of U triangle: diagonal not equal")
 		}
 	}
 }

--- a/mat64/vector_test.go
+++ b/mat64/vector_test.go
@@ -2,12 +2,12 @@ package mat64
 
 import (
 	"reflect"
+	"testing"
 
 	"github.com/gonum/blas/blas64"
-	"gopkg.in/check.v1"
 )
 
-func (s *S) TestNewVector(c *check.C) {
+func TestNewVector(t *testing.T) {
 	for i, test := range []struct {
 		n      int
 		data   []float64
@@ -39,18 +39,18 @@ func (s *S) TestNewVector(c *check.C) {
 		v := NewVector(test.n, test.data)
 		rows, cols := v.Dims()
 		if rows != test.n {
-			c.Errorf("unexpected number of rows for test %d: got: %d want: %d", i, rows, test.n)
+			t.Errorf("unexpected number of rows for test %d: got: %d want: %d", i, rows, test.n)
 		}
 		if cols != 1 {
-			c.Errorf("unexpected number of cols for test %d: got: %d want: 1", i, cols)
+			t.Errorf("unexpected number of cols for test %d: got: %d want: 1", i, cols)
 		}
 		if !reflect.DeepEqual(v, test.vector) {
-			c.Errorf("unexpected data slice for test %d: got: %v want: %v", i, v, test.vector)
+			t.Errorf("unexpected data slice for test %d: got: %v want: %v", i, v, test.vector)
 		}
 	}
 }
 
-func (s *S) TestVectorAtSet(c *check.C) {
+func TestVectorAtSet(t *testing.T) {
 	for i, test := range []struct {
 		vector *Vector
 	}{
@@ -79,39 +79,39 @@ func (s *S) TestVectorAtSet(c *check.C) {
 		for _, row := range []int{-1, n} {
 			panicked, message := panics(func() { v.At(row, 0) })
 			if !panicked || message != ErrRowAccess.Error() {
-				c.Errorf("expected panic for invalid row access for test %d n=%d r=%d", i, n, row)
+				t.Errorf("expected panic for invalid row access for test %d n=%d r=%d", i, n, row)
 			}
 		}
 		for _, col := range []int{-1, 1} {
 			panicked, message := panics(func() { v.At(0, col) })
 			if !panicked || message != ErrColAccess.Error() {
-				c.Errorf("expected panic for invalid column access for test %d n=%d c=%d", i, n, col)
+				t.Errorf("expected panic for invalid column access for test %d n=%d c=%d", i, n, col)
 			}
 		}
 
 		for _, row := range []int{0, 1, n - 1} {
 			if e := v.At(row, 0); e != float64(row) {
-				c.Errorf("unexpected value for At(%d, 0) for test %d : got: %v want: %v", row, i, e, float64(row))
+				t.Errorf("unexpected value for At(%d, 0) for test %d : got: %v want: %v", row, i, e, float64(row))
 			}
 		}
 
 		for _, row := range []int{-1, n} {
 			panicked, message := panics(func() { v.SetVec(row, 100) })
 			if !panicked || message != ErrVectorAccess.Error() {
-				c.Errorf("expected panic for invalid row access for test %d n=%d r=%d", i, n, row)
+				t.Errorf("expected panic for invalid row access for test %d n=%d r=%d", i, n, row)
 			}
 		}
 
 		for inc, row := range []int{0, 2} {
 			v.SetVec(row, 100+float64(inc))
 			if e := v.At(row, 0); e != 100+float64(inc) {
-				c.Errorf("unexpected value for At(%d, 0) after SetVec(%[1]d, %v) for test %d: got: %v want: %[2]v", row, 100+float64(inc), i, e)
+				t.Errorf("unexpected value for At(%d, 0) after SetVec(%[1]d, %v) for test %d: got: %v want: %[2]v", row, 100+float64(inc), i, e)
 			}
 		}
 	}
 }
 
-func (s *S) TestVectorMul(c *check.C) {
+func TestVectorMul(t *testing.T) {
 	method := func(receiver, a, b Matrix) {
 		type mulVecer interface {
 			MulVec(a Matrix, b *Vector)
@@ -131,10 +131,10 @@ func (s *S) TestVectorMul(c *check.C) {
 		}
 		return legal
 	}
-	testTwoInput(c, "MulVec", &Vector{}, method, denseComparison, legalTypesNotVecVec, legalSizeMulVec, 1e-14)
+	testTwoInput(t, "MulVec", &Vector{}, method, denseComparison, legalTypesNotVecVec, legalSizeMulVec, 1e-14)
 }
 
-func (s *S) TestVectorAdd(c *check.C) {
+func TestVectorAdd(t *testing.T) {
 	for i, test := range []struct {
 		a, b *Vector
 		want *Vector
@@ -158,12 +158,12 @@ func (s *S) TestVectorAdd(c *check.C) {
 		var v Vector
 		v.AddVec(test.a, test.b)
 		if !reflect.DeepEqual(v.RawVector(), test.want.RawVector()) {
-			c.Errorf("unexpected result for test %d: got: %v want: %v", i, v.RawVector(), test.want.RawVector())
+			t.Errorf("unexpected result for test %d: got: %v want: %v", i, v.RawVector(), test.want.RawVector())
 		}
 	}
 }
 
-func (s *S) TestVectorSub(c *check.C) {
+func TestVectorSub(t *testing.T) {
 	for i, test := range []struct {
 		a, b *Vector
 		want *Vector
@@ -187,12 +187,12 @@ func (s *S) TestVectorSub(c *check.C) {
 		var v Vector
 		v.SubVec(test.a, test.b)
 		if !reflect.DeepEqual(v.RawVector(), test.want.RawVector()) {
-			c.Errorf("unexpected result for test %d: got: %v want: %v", i, v.RawVector(), test.want.RawVector())
+			t.Errorf("unexpected result for test %d: got: %v want: %v", i, v.RawVector(), test.want.RawVector())
 		}
 	}
 }
 
-func (s *S) TestVectorMulElem(c *check.C) {
+func TestVectorMulElem(t *testing.T) {
 	for i, test := range []struct {
 		a, b *Vector
 		want *Vector
@@ -216,12 +216,12 @@ func (s *S) TestVectorMulElem(c *check.C) {
 		var v Vector
 		v.MulElemVec(test.a, test.b)
 		if !reflect.DeepEqual(v.RawVector(), test.want.RawVector()) {
-			c.Errorf("unexpected result for test %d: got: %v want: %v", i, v.RawVector(), test.want.RawVector())
+			t.Errorf("unexpected result for test %d: got: %v want: %v", i, v.RawVector(), test.want.RawVector())
 		}
 	}
 }
 
-func (s *S) TestVectorDivElem(c *check.C) {
+func TestVectorDivElem(t *testing.T) {
 	for i, test := range []struct {
 		a, b *Vector
 		want *Vector
@@ -245,7 +245,7 @@ func (s *S) TestVectorDivElem(c *check.C) {
 		var v Vector
 		v.DivElemVec(test.a, test.b)
 		if !reflect.DeepEqual(v.RawVector(), test.want.RawVector()) {
-			c.Errorf("unexpected result for test %d: got: %v want: %v", i, v.RawVector(), test.want.RawVector())
+			t.Errorf("unexpected result for test %d: got: %v want: %v", i, v.RawVector(), test.want.RawVector())
 		}
 	}
 }


### PR DESCRIPTION
The text of many of the test errors should be improved, but that can be a subsequent PR which should go over the tests and clean up some of the older style that persisted from biogo.matrix.

@btracey Please take a look.