### PR TITLE
mat64: add overlap detection for blas64 returning types

### DIFF
--- a/mat64/dense_arithmetic.go
+++ b/mat64/dense_arithmetic.go
@@ -350,10 +350,16 @@ func (m *Dense) Mul(a, b Matrix) {
 	// temporary memory.
 	// C = A^T * B = (B^T * A)^T
 	// C^T = B^T * A.
-	if aU, ok := aU.(RawMatrixer); ok {
-		amat := aU.RawMatrix()
-		if bU, ok := bU.(RawMatrixer); ok {
-			bmat := bU.RawMatrix()
+	if aUrm, ok := aU.(RawMatrixer); ok {
+		amat := aUrm.RawMatrix()
+		if restore == nil {
+			m.checkOverlap(amat)
+		}
+		if bUrm, ok := bU.(RawMatrixer); ok {
+			bmat := bUrm.RawMatrix()
+			if restore == nil {
+				m.checkOverlap(bmat)
+			}
 			blas64.Gemm(aT, bT, 1, amat, bmat, 0, m.mat)
 			return
 		}
@@ -375,7 +381,7 @@ func (m *Dense) Mul(a, b Matrix) {
 			if aTrans {
 				c := getWorkspace(ac, ar, false)
 				var tmp Dense
-				tmp.SetRawMatrix(aU.RawMatrix())
+				tmp.SetRawMatrix(amat)
 				c.Copy(&tmp)
 				bT := blas.Trans
 				if bTrans {
@@ -412,8 +418,11 @@ func (m *Dense) Mul(a, b Matrix) {
 			return
 		}
 	}
-	if bU, ok := bU.(RawMatrixer); ok {
-		bmat := bU.RawMatrix()
+	if bUrm, ok := bU.(RawMatrixer); ok {
+		bmat := bUrm.RawMatrix()
+		if restore == nil {
+			m.checkOverlap(bmat)
+		}
 		if aU, ok := aU.(RawSymmetricer); ok {
 			amat := aU.RawSymmetric()
 			if bTrans {
@@ -432,7 +441,7 @@ func (m *Dense) Mul(a, b Matrix) {
 			if bTrans {
 				c := getWorkspace(bc, br, false)
 				var tmp Dense
-				tmp.SetRawMatrix(bU.RawMatrix())
+				tmp.SetRawMatrix(bmat)
 				c.Copy(&tmp)
 				aT := blas.Trans
 				if aTrans {

--- a/mat64/dense_arithmetic.go
+++ b/mat64/dense_arithmetic.go
@@ -29,18 +29,15 @@ func (m *Dense) Add(a, b Matrix) {
 	aMat, _ := untranspose(a)
 	bMat, _ := untranspose(b)
 	m.reuseAs(ar, ac)
-	var restore func()
-	if m == aMat {
-		m, restore = m.isolatedWorkspace(aMat)
-		defer restore()
-	} else if m == bMat {
-		m, restore = m.isolatedWorkspace(bMat)
-		defer restore()
-	}
 
-	if a, ok := a.(RawMatrixer); ok {
-		if b, ok := b.(RawMatrixer); ok {
-			amat, bmat := a.RawMatrix(), b.RawMatrix()
+	if arm, ok := a.(RawMatrixer); ok {
+		if brm, ok := b.(RawMatrixer); ok {
+			amat, bmat := arm.RawMatrix(), brm.RawMatrix()
+			if m != aMat {
+				m.checkOverlap(amat)
+			} else if m != bMat {
+				m.checkOverlap(bmat)
+			}
 			for ja, jb, jm := 0, 0, 0; ja < ar*amat.Stride; ja, jb, jm = ja+amat.Stride, jb+bmat.Stride, jm+m.mat.Stride {
 				for i, v := range amat.Data[ja : ja+ac] {
 					m.mat.Data[i+jm] = v + bmat.Data[i+jb]
@@ -48,6 +45,15 @@ func (m *Dense) Add(a, b Matrix) {
 			}
 			return
 		}
+	}
+
+	var restore func()
+	if m == aMat {
+		m, restore = m.isolatedWorkspace(aMat)
+		defer restore()
+	} else if m == bMat {
+		m, restore = m.isolatedWorkspace(bMat)
+		defer restore()
 	}
 
 	if a, ok := a.(Vectorer); ok {
@@ -84,18 +90,15 @@ func (m *Dense) Sub(a, b Matrix) {
 	aMat, _ := untranspose(a)
 	bMat, _ := untranspose(b)
 	m.reuseAs(ar, ac)
-	var restore func()
-	if m == aMat {
-		m, restore = m.isolatedWorkspace(aMat)
-		defer restore()
-	} else if m == bMat {
-		m, restore = m.isolatedWorkspace(bMat)
-		defer restore()
-	}
 
-	if a, ok := a.(RawMatrixer); ok {
-		if b, ok := b.(RawMatrixer); ok {
-			amat, bmat := a.RawMatrix(), b.RawMatrix()
+	if arm, ok := a.(RawMatrixer); ok {
+		if brm, ok := b.(RawMatrixer); ok {
+			amat, bmat := arm.RawMatrix(), brm.RawMatrix()
+			if m != aMat {
+				m.checkOverlap(amat)
+			} else if m != bMat {
+				m.checkOverlap(bmat)
+			}
 			for ja, jb, jm := 0, 0, 0; ja < ar*amat.Stride; ja, jb, jm = ja+amat.Stride, jb+bmat.Stride, jm+m.mat.Stride {
 				for i, v := range amat.Data[ja : ja+ac] {
 					m.mat.Data[i+jm] = v - bmat.Data[i+jb]
@@ -103,6 +106,15 @@ func (m *Dense) Sub(a, b Matrix) {
 			}
 			return
 		}
+	}
+
+	var restore func()
+	if m == aMat {
+		m, restore = m.isolatedWorkspace(aMat)
+		defer restore()
+	} else if m == bMat {
+		m, restore = m.isolatedWorkspace(bMat)
+		defer restore()
 	}
 
 	if a, ok := a.(Vectorer); ok {
@@ -140,18 +152,15 @@ func (m *Dense) MulElem(a, b Matrix) {
 	aMat, _ := untranspose(a)
 	bMat, _ := untranspose(b)
 	m.reuseAs(ar, ac)
-	var restore func()
-	if m == aMat {
-		m, restore = m.isolatedWorkspace(aMat)
-		defer restore()
-	} else if m == bMat {
-		m, restore = m.isolatedWorkspace(bMat)
-		defer restore()
-	}
 
-	if a, ok := a.(RawMatrixer); ok {
-		if b, ok := b.(RawMatrixer); ok {
-			amat, bmat := a.RawMatrix(), b.RawMatrix()
+	if arm, ok := a.(RawMatrixer); ok {
+		if brm, ok := b.(RawMatrixer); ok {
+			amat, bmat := arm.RawMatrix(), brm.RawMatrix()
+			if m != aMat {
+				m.checkOverlap(amat)
+			} else if m != bMat {
+				m.checkOverlap(bmat)
+			}
 			for ja, jb, jm := 0, 0, 0; ja < ar*amat.Stride; ja, jb, jm = ja+amat.Stride, jb+bmat.Stride, jm+m.mat.Stride {
 				for i, v := range amat.Data[ja : ja+ac] {
 					m.mat.Data[i+jm] = v * bmat.Data[i+jb]
@@ -159,6 +168,15 @@ func (m *Dense) MulElem(a, b Matrix) {
 			}
 			return
 		}
+	}
+
+	var restore func()
+	if m == aMat {
+		m, restore = m.isolatedWorkspace(aMat)
+		defer restore()
+	} else if m == bMat {
+		m, restore = m.isolatedWorkspace(bMat)
+		defer restore()
 	}
 
 	if a, ok := a.(Vectorer); ok {
@@ -196,18 +214,15 @@ func (m *Dense) DivElem(a, b Matrix) {
 	aMat, _ := untranspose(a)
 	bMat, _ := untranspose(b)
 	m.reuseAs(ar, ac)
-	var restore func()
-	if m == aMat {
-		m, restore = m.isolatedWorkspace(aMat)
-		defer restore()
-	} else if m == bMat {
-		m, restore = m.isolatedWorkspace(bMat)
-		defer restore()
-	}
 
-	if a, ok := a.(RawMatrixer); ok {
-		if b, ok := b.(RawMatrixer); ok {
-			amat, bmat := a.RawMatrix(), b.RawMatrix()
+	if arm, ok := a.(RawMatrixer); ok {
+		if brm, ok := b.(RawMatrixer); ok {
+			amat, bmat := arm.RawMatrix(), brm.RawMatrix()
+			if m != aMat {
+				m.checkOverlap(amat)
+			} else if m != bMat {
+				m.checkOverlap(bmat)
+			}
 			for ja, jb, jm := 0, 0, 0; ja < ar*amat.Stride; ja, jb, jm = ja+amat.Stride, jb+bmat.Stride, jm+m.mat.Stride {
 				for i, v := range amat.Data[ja : ja+ac] {
 					m.mat.Data[i+jm] = v / bmat.Data[i+jb]
@@ -215,6 +230,15 @@ func (m *Dense) DivElem(a, b Matrix) {
 			}
 			return
 		}
+	}
+
+	var restore func()
+	if m == aMat {
+		m, restore = m.isolatedWorkspace(aMat)
+		defer restore()
+	} else if m == bMat {
+		m, restore = m.isolatedWorkspace(bMat)
+		defer restore()
 	}
 
 	if a, ok := a.(Vectorer); ok {

--- a/mat64/lu.go
+++ b/mat64/lu.go
@@ -250,7 +250,10 @@ func (m *Dense) SolveLU(lu *LU, trans bool, b Matrix) error {
 	if m == bMat {
 		m, restore = m.isolatedWorkspace(bMat)
 		defer restore()
+	} else if rm, ok := bMat.(RawMatrixer); ok {
+		m.checkOverlap(rm.RawMatrix())
 	}
+
 	m.Copy(b)
 	t := blas.NoTrans
 	if trans {

--- a/mat64/offset.go
+++ b/mat64/offset.go
@@ -1,0 +1,26 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//+build !appengine
+
+package mat64
+
+import "unsafe"
+
+// offset returns the number of float64 values b[0] is after a[0].
+func offset(a, b []float64) int {
+	// This block must be atomic with respect to GC moves.
+	// At this stage this is true, because the GC does not
+	// move.
+	a0 := uintptr(unsafe.Pointer(&a[0]))
+	b0 := uintptr(unsafe.Pointer(&b[0]))
+
+	if a0 == b0 {
+		return 0
+	}
+	if a0 < b0 {
+		return int((b0 - a0) / unsafe.Sizeof(float64(0)))
+	}
+	return -int((a0 - b0) / unsafe.Sizeof(float64(0)))
+}

--- a/mat64/offset_appengine.go
+++ b/mat64/offset_appengine.go
@@ -1,0 +1,28 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//+build appengine
+
+package mat64
+
+import "reflect"
+
+var sizeOfFloat64 = reflect.TypeOf(float64(0)).Size()
+
+// offset returns the number of float64 values b[0] is after a[0].
+func offset(a, b []float64) int {
+	// This block must be atomic with respect to GC moves.
+	// At this stage this is true, because the GC does not
+	// move.
+	a0 := reflect.ValueOf(a).Index(0).UnsafeAddr()
+	b0 := reflect.ValueOf(b).Index(0).UnsafeAddr()
+
+	if a0 == b0 {
+		return 0
+	}
+	if a0 < b0 {
+		return int((b0 - a0) / sizeOfFloat64)
+	}
+	return -int((a0 - b0) / sizeOfFloat64)
+}

--- a/mat64/shadow.go
+++ b/mat64/shadow.go
@@ -1,0 +1,201 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mat64
+
+import "github.com/gonum/blas/blas64"
+
+const (
+	// regionOverlap is the panic string used for the general case
+	// of a matrix region overlap between a source and destination.
+	regionOverlap = "mat64: bad region: overlap"
+
+	// regionIdentity is the panic string used for the specific
+	// case of complete agreement between a source and a destination.
+	regionIdentity = "mat64: bad region: identical"
+
+	// mismatchedStrides is the panic string used for overlapping
+	// data slices with differing strides.
+	mismatchedStrides = "mat64: bad region: different strides"
+)
+
+// checkOverlap returns false if the receiver does not overlap data elements
+// referenced by the parameter and panics otherwise.
+//
+// checkOverlap methods return a boolean to allow the check call to be added to a
+// boolean expression, making use of short-circuit operators.
+
+func (m *Dense) checkOverlap(a blas64.General) bool {
+	mat := m.RawMatrix()
+	if cap(mat.Data) == 0 || cap(a.Data) == 0 {
+		return false
+	}
+
+	off := offset(mat.Data[:1], a.Data[:1])
+
+	if off == 0 {
+		// At least one element overlaps.
+		if mat.Cols == a.Cols && mat.Rows == a.Rows && mat.Stride == a.Stride {
+			panic(regionIdentity)
+		}
+		panic(regionOverlap)
+	}
+
+	if off > 0 && len(mat.Data) <= off {
+		// We know m is completely before a.
+		return false
+	}
+	if off < 0 && len(a.Data) <= -off {
+		// We know m is completely after a.
+		return false
+	}
+
+	if mat.Stride != a.Stride {
+		// Too hard, so assume the worst.
+		panic(mismatchedStrides)
+	}
+
+	if off < 0 {
+		off = -off
+		mat.Cols, a.Cols = a.Cols, mat.Cols
+	}
+	if rectanglesOverlap(off, mat.Cols, a.Cols, mat.Stride) {
+		panic(regionOverlap)
+	}
+	return false
+}
+
+func (s *SymDense) checkOverlap(a blas64.Symmetric) bool {
+	mat := s.RawSymmetric()
+	if cap(mat.Data) == 0 || cap(a.Data) == 0 {
+		return false
+	}
+
+	off := offset(mat.Data[:1], a.Data[:1])
+
+	if off == 0 {
+		// At least one element overlaps.
+		if mat.N == a.N && mat.Stride == a.Stride {
+			panic(regionIdentity)
+		}
+		panic(regionOverlap)
+	}
+
+	if off > 0 && len(mat.Data) <= off {
+		// We know s is completely before a.
+		return false
+	}
+	if off < 0 && len(a.Data) <= -off {
+		// We know s is completely after a.
+		return false
+	}
+
+	if mat.Stride != a.Stride {
+		// Too hard, so assume the worst.
+		panic(mismatchedStrides)
+	}
+
+	// TODO(kortschak) Make this analysis more precise.
+	if off > 0 {
+		off = -off
+		mat.N, a.N = a.N, mat.N
+	}
+	if rectanglesOverlap(off, mat.N, a.N, mat.Stride) {
+		panic(regionOverlap)
+	}
+	return false
+}
+
+func (t *TriDense) checkOverlap(a blas64.Triangular) bool {
+	mat := t.RawTriangular()
+	if cap(mat.Data) == 0 || cap(a.Data) == 0 {
+		return false
+	}
+
+	off := offset(mat.Data[:1], a.Data[:1])
+
+	if off == 0 {
+		// At least one element overlaps.
+		if mat.N == a.N && mat.Stride == a.Stride {
+			panic(regionIdentity)
+		}
+		panic(regionOverlap)
+	}
+
+	if off > 0 && len(mat.Data) <= off {
+		// We know t is completely before a.
+		return false
+	}
+	if off < 0 && len(a.Data) <= -off {
+		// We know t is completely after a.
+		return false
+	}
+
+	if mat.Stride != a.Stride {
+		// Too hard, so assume the worst.
+		panic(mismatchedStrides)
+	}
+
+	// TODO(kortschak) Make this analysis more precise.
+	if off > 0 {
+		off = -off
+		mat.N, a.N = a.N, mat.N
+	}
+	if rectanglesOverlap(off, mat.N, a.N, mat.Stride) {
+		panic(regionOverlap)
+	}
+	return false
+}
+
+func (v *Vector) checkOverlap(a blas64.Vector) bool {
+	mat := v.mat
+	if cap(mat.Data) == 0 || cap(a.Data) == 0 {
+		return false
+	}
+
+	off := offset(mat.Data[:1], a.Data[:1])
+
+	if off == 0 {
+		// At least one element overlaps.
+		if mat.Inc == a.Inc && len(mat.Data) == len(a.Data) {
+			panic(regionIdentity)
+		}
+		panic(regionOverlap)
+	}
+
+	if off > 0 && len(mat.Data) <= off {
+		// We know v is completely before a.
+		return false
+	}
+	if off < 0 && len(a.Data) <= -off {
+		// We know v is completely after a.
+		return false
+	}
+
+	if mat.Inc != a.Inc {
+		// Too hard, so assume the worst.
+		panic(mismatchedStrides)
+	}
+
+	if mat.Inc == 1 || off&mat.Inc == 0 {
+		panic(regionOverlap)
+	}
+	return false
+}
+
+// rectanglesOverlap returns whether the strided rectangles a and b overlap
+// when b is offset by off elements after a but has at least one element before
+// the end of a. a and b have aCols and bCols respectively.
+func rectanglesOverlap(off, aCols, bCols, stride int) bool {
+	if stride == 1 {
+		return true
+	}
+	aTo := aCols
+	bFrom := off % stride
+	bTo := (bFrom + bCols) % stride
+	if bFrom < bTo {
+		return aTo > bFrom
+	}
+	return bTo > 0
+}

--- a/mat64/shadow_test.go
+++ b/mat64/shadow_test.go
@@ -1,0 +1,91 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mat64
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestDenseOverlaps(t *testing.T) {
+	type view struct {
+		i, j, r, c int
+		*Dense
+	}
+
+	for r := 1; r < 20; r++ {
+		for c := 1; c < 20; c++ {
+			m := NewDense(r, c, nil)
+			panicked, message := panics(func() { m.checkOverlap(m.RawMatrix()) })
+			if !panicked {
+				t.Error("expected matrix overlap with self")
+			}
+			if message != regionIdentity {
+				t.Errorf("unexpected panic message for self overlap: got: %q want: %q", message, regionIdentity)
+			}
+
+			for i := 0; i < 1000; i++ {
+				var views [2]view
+				for k := range views {
+					if r > 1 {
+						views[k].i = rand.Intn(r - 1)
+					}
+					if c > 1 {
+						views[k].j = rand.Intn(c - 1)
+					}
+					if r > 1 {
+						views[k].r = rand.Intn(r-views[k].i-1) + 1
+					} else {
+						views[k].r = 1
+					}
+					if c > 1 {
+						views[k].c = rand.Intn(c-views[k].j-1) + 1
+					} else {
+						views[k].c = 1
+					}
+					views[k].Dense = m.View(views[k].i, views[k].j, views[k].r, views[k].c).(*Dense)
+
+					panicked, _ = panics(func() { m.checkOverlap(views[k].RawMatrix()) })
+					if !panicked {
+						t.Errorf("expected matrix (%d×%d) overlap with view {rows=%d:%d, cols=%d:%d}",
+							r, c, views[k].i, views[k].i+views[k].r, views[k].j, views[k].j+views[k].c)
+					}
+					panicked, _ = panics(func() { views[k].checkOverlap(m.RawMatrix()) })
+					if !panicked {
+						t.Errorf("expected view {rows=%d:%d, cols=%d:%d} overlap with parent (%d×%d)",
+							views[k].i, views[k].i+views[k].r, views[k].j, views[k].j+views[k].c, r, c)
+					}
+				}
+
+				overlapRows := intervalsOverlap(
+					interval{views[0].i, views[0].i + views[0].r},
+					interval{views[1].i, views[1].i + views[1].r},
+				)
+				overlapCols := intervalsOverlap(
+					interval{views[0].j, views[0].j + views[0].c},
+					interval{views[1].j, views[1].j + views[1].c},
+				)
+				want := overlapRows && overlapCols
+
+				for k, v := range views {
+					w := views[1-k]
+					got, _ := panics(func() { v.checkOverlap(w.RawMatrix()) })
+					if got != want {
+						t.Errorf("unexpected result for overlap test for {rows=%d:%d, cols=%d:%d} with {rows=%d:%d, cols=%d:%d}: got: %t want: %t",
+							v.i, v.i+v.r, v.j, v.j+v.c,
+							w.i, w.i+w.r, w.j, w.j+w.c,
+							got, want)
+					}
+				}
+			}
+		}
+	}
+}
+
+type interval struct{ from, to int }
+
+func intervalsOverlap(a, b interval) bool {
+	return a.to > b.from && b.to > a.from
+}


### PR DESCRIPTION
This provides the necessary tools for adding shadowing detection. There is currently no testing for the symmetric or triangular matrix overlaps methods, but they are substantively the same as the general matrix case and it is not yet clear how views of those types will arise - clients can do it and I guess we might at some stage add ViewSym and ViewTri or some near equivalent.

The test is conservative in general (mismatched stride makes a yes if the matrix data slices overlap at all - this should never happen), but more so with the symmetric and triangular cases because of ease of coding.

Updates #200.

@btracey Please take a look.