### PR TITLE
Add special case for *Vector in mat64.Norm

### DIFF
--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -695,6 +695,9 @@ func Norm(a Matrix, norm float64) float64 {
 		}
 		return lapack64.Lansy(n, rm, work)
 	case *Vector:
+		if rma.isZero() {
+			return 0
+		}
 		rv := rma.RawVector()
 		switch norm {
 		default:

--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -694,6 +694,26 @@ func Norm(a Matrix, norm float64) float64 {
 			work = make([]float64, rm.N)
 		}
 		return lapack64.Lansy(n, rm, work)
+	case *Vector:
+		rv := rma.RawVector()
+		switch norm {
+		default:
+			panic("unreachable")
+		case 1:
+			if aTrans {
+				imax := blas64.Iamax(rma.n, rv)
+				return math.Abs(rma.At(imax, 0))
+			}
+			return blas64.Asum(rma.n, rv)
+		case 2:
+			return blas64.Nrm2(rma.n, rv)
+		case math.Inf(1):
+			if aTrans {
+				return blas64.Asum(rma.n, rv)
+			}
+			imax := blas64.Iamax(rma.n, rv)
+			return math.Abs(rma.At(imax, 0))
+		}
 	}
 	switch norm {
 	default:

--- a/mat64/matrix_test.go
+++ b/mat64/matrix_test.go
@@ -263,10 +263,15 @@ func TestNormZero(t *testing.T) {
 		&TriDense{mat: blas64.Triangular{Uplo: blas.Upper, Diag: blas.NonUnit}},
 		&Vector{},
 	} {
+		want := 0.0
 		for _, norm := range []float64{1, 2, math.Inf(1)} {
-			panicked, message := panics(func() { Norm(a, norm) })
+			var got float64
+			panicked, message := panics(func() { got = Norm(a, norm) })
 			if panicked {
 				t.Errorf("unexpected panic for Norm(&%T{}, %v): %v", a, norm, message)
+			}
+			if got != want {
+				t.Errorf("unexpected result for Norm(&%T{}, %v). Want %v, got %v", a, norm, want, got)
 			}
 		}
 	}

--- a/mat64/matrix_test.go
+++ b/mat64/matrix_test.go
@@ -8,6 +8,9 @@ import (
 	"fmt"
 	"math"
 	"testing"
+
+	"github.com/gonum/blas"
+	"github.com/gonum/blas/blas64"
 )
 
 var inf = math.Inf(1)
@@ -251,6 +254,22 @@ func TestNorm(t *testing.T) {
 		return Norm(a, math.Inf(1))
 	}
 	testOneInputFunc(t, "Norm_inf", f, denseComparison, sameAnswerFloatApprox, isAnyType, isAnySize)
+}
+
+func TestNormZero(t *testing.T) {
+	for _, a := range []Matrix{
+		&Dense{},
+		&SymDense{mat: blas64.Symmetric{Uplo: blas.Upper}},
+		&TriDense{mat: blas64.Triangular{Uplo: blas.Upper, Diag: blas.NonUnit}},
+		&Vector{},
+	} {
+		for _, norm := range []float64{1, 2, math.Inf(1)} {
+			panicked, message := panics(func() { Norm(a, norm) })
+			if panicked {
+				t.Errorf("unexpected panic for Norm(&%T{}, %v): %v", a, norm, message)
+			}
+		}
+	}
 }
 
 func TestSum(t *testing.T) {

--- a/mat64/vector.go
+++ b/mat64/vector.go
@@ -85,7 +85,12 @@ func (v *Vector) ViewVec(i, n int) *Vector {
 	}
 }
 
-func (v *Vector) Dims() (r, c int) { return v.n, 1 }
+func (v *Vector) Dims() (r, c int) {
+	if v.isZero() {
+		return 0, 0
+	}
+	return v.n, 1
+}
 
 // Len returns the length of the vector.
 func (v *Vector) Len() int {
@@ -324,7 +329,7 @@ func (v *Vector) reuseAs(r int) {
 
 func (v *Vector) isZero() bool {
 	// It must be the case that v.Dims() returns
-	// zeros in this case. See comment in Reset().
+	// zeros in this case.
 	return v.mat.Inc == 0
 }
 

--- a/mat64/vector.go
+++ b/mat64/vector.go
@@ -102,10 +102,16 @@ func (v *Vector) T() Matrix {
 	return Transpose{v}
 }
 
+// Reset zeros the length of the vector so that it can be reused as the
+// receiver of a dimensionally restricted operation.
+//
+// See the Reseter interface for more information.
 func (v *Vector) Reset() {
-	v.mat.Data = v.mat.Data[:0]
+	// No change of Inc or n to 0 may be
+	// made unless both are set to 0.
 	v.mat.Inc = 0
 	v.n = 0
+	v.mat.Data = v.mat.Data[:0]
 }
 
 func (v *Vector) RawVector() blas64.Vector {
@@ -329,7 +335,7 @@ func (v *Vector) reuseAs(r int) {
 
 func (v *Vector) isZero() bool {
 	// It must be the case that v.Dims() returns
-	// zeros in this case.
+	// zeros in this case. See comment in Reset().
 	return v.mat.Inc == 0
 }
 


### PR DESCRIPTION
What about this, is it ok? That `case *Vector:` doesn't blend in with the other `Raw...er` cases but unlike the other blas64 types, Vector does not carry enough information for the blas calls. Would relying on Dims() be safe?