### PR TITLE
Add Vector.AddScaledVec

### DIFF
--- a/mat64/list_test.go
+++ b/mat64/list_test.go
@@ -56,6 +56,12 @@ func legalSizeSolve(ar, ac, br, bc int) bool {
 	return ar == br
 }
 
+// legalSizeSameVec returns whether the two matrices are column vectors of the
+// same dimension.
+func legalSizeSameVec(ar, ac, br, bc int) bool {
+	return ac == 1 && bc == 1 && ar == br
+}
+
 // isAnySize returns true for all matrix sizes.
 func isAnySize(ar, ac int) bool {
 	return true
@@ -138,6 +144,17 @@ func legalTypesSym(a, b Matrix) bool {
 func legalTypeVec(v Matrix) bool {
 	_, ok := v.(*Vector)
 	return ok
+}
+
+// legalTypesVecVec returns whether both inputs are *Vector.
+func legalTypesVecVec(a, b Matrix) bool {
+	if _, ok := a.(*Vector); !ok {
+		return false
+	}
+	if _, ok := b.(*Vector); !ok {
+		return false
+	}
+	return true
 }
 
 // legalTypesNotVecVec returns whether the first input is an arbitrary Matrix

--- a/mat64/vector.go
+++ b/mat64/vector.go
@@ -137,6 +137,31 @@ func (v *Vector) ScaleVec(alpha float64, a *Vector) {
 	blas64.Scal(n, alpha, v.mat)
 }
 
+// AddScaledVec adds the vectors a and alpha*b, placing the result in the receiver.
+func (v *Vector) AddScaledVec(a *Vector, alpha float64, b *Vector) {
+	ar := a.Len()
+	br := b.Len()
+
+	if ar != br {
+		panic(ErrShape)
+	}
+
+	v.reuseAs(ar)
+
+	switch {
+	case v == a && v == b: // v <- v + alpha * v = (alpha + 1) * v
+		blas64.Scal(ar, alpha+1, v.mat)
+	case v == a && v != b: // v <- v + alpha * b
+		blas64.Axpy(ar, alpha, b.mat, v.mat)
+	case v != a && v == b: // v <- a + alpha * v
+		blas64.Scal(ar, alpha, v.mat)
+		blas64.Axpy(ar, 1, a.mat, v.mat)
+	default: // v <- a + alpha * b
+		blas64.Copy(ar, a.mat, v.mat)
+		blas64.Axpy(ar, alpha, b.mat, v.mat)
+	}
+}
+
 // AddVec adds a and b element-wise, placing the result in the receiver.
 func (v *Vector) AddVec(a, b *Vector) {
 	ar := a.Len()

--- a/mat64/vector_test.go
+++ b/mat64/vector_test.go
@@ -208,6 +208,24 @@ func TestVectorScale(t *testing.T) {
 	}
 }
 
+func TestVectorAddScaled(t *testing.T) {
+	for _, alpha := range []float64{0, 1, -1, 2.3, -2.3} {
+		method := func(receiver, a, b Matrix) {
+			type addScaledVecer interface {
+				AddScaledVec(*Vector, float64, *Vector)
+			}
+			v := receiver.(addScaledVecer)
+			v.AddScaledVec(a.(*Vector), alpha, b.(*Vector))
+		}
+		denseComparison := func(receiver, a, b *Dense) {
+			var sb Dense
+			sb.Scale(alpha, b)
+			receiver.Add(a, &sb)
+		}
+		testTwoInput(t, "AddScaledVec", &Vector{}, method, denseComparison, legalTypesVecVec, legalSizeSameVec, 1e-14)
+	}
+}
+
 func TestVectorAdd(t *testing.T) {
 	for i, test := range []struct {
 		a, b *Vector


### PR DESCRIPTION
Without this addition, some operations on Vectors require a temporary with the present Vector API.

Possibly a better name for the method would be `ScaleAddVec`.

`Add` and `Sub` could be removed but probably we will keep them for convenience. If kept, they should call the new method.

@btracey @kortschak Please take a look.