### PR TITLE
mat64: rename [ab]Mat => [ab]U where it is an untranspose

### DIFF
--- a/mat64/dense_arithmetic.go
+++ b/mat64/dense_arithmetic.go
@@ -26,17 +26,17 @@ func (m *Dense) Add(a, b Matrix) {
 		panic(ErrShape)
 	}
 
-	aMat, _ := untranspose(a)
-	bMat, _ := untranspose(b)
+	aU, _ := untranspose(a)
+	bU, _ := untranspose(b)
 	m.reuseAs(ar, ac)
 
 	if arm, ok := a.(RawMatrixer); ok {
 		if brm, ok := b.(RawMatrixer); ok {
 			amat, bmat := arm.RawMatrix(), brm.RawMatrix()
-			if m != aMat {
+			if m != aU {
 				m.checkOverlap(amat)
 			}
-			if m != bMat {
+			if m != bU {
 				m.checkOverlap(bmat)
 			}
 			for ja, jb, jm := 0, 0, 0; ja < ar*amat.Stride; ja, jb, jm = ja+amat.Stride, jb+bmat.Stride, jm+m.mat.Stride {
@@ -49,11 +49,11 @@ func (m *Dense) Add(a, b Matrix) {
 	}
 
 	var restore func()
-	if m == aMat {
-		m, restore = m.isolatedWorkspace(aMat)
+	if m == aU {
+		m, restore = m.isolatedWorkspace(aU)
 		defer restore()
-	} else if m == bMat {
-		m, restore = m.isolatedWorkspace(bMat)
+	} else if m == bU {
+		m, restore = m.isolatedWorkspace(bU)
 		defer restore()
 	}
 
@@ -88,17 +88,17 @@ func (m *Dense) Sub(a, b Matrix) {
 		panic(ErrShape)
 	}
 
-	aMat, _ := untranspose(a)
-	bMat, _ := untranspose(b)
+	aU, _ := untranspose(a)
+	bU, _ := untranspose(b)
 	m.reuseAs(ar, ac)
 
 	if arm, ok := a.(RawMatrixer); ok {
 		if brm, ok := b.(RawMatrixer); ok {
 			amat, bmat := arm.RawMatrix(), brm.RawMatrix()
-			if m != aMat {
+			if m != aU {
 				m.checkOverlap(amat)
 			}
-			if m != bMat {
+			if m != bU {
 				m.checkOverlap(bmat)
 			}
 			for ja, jb, jm := 0, 0, 0; ja < ar*amat.Stride; ja, jb, jm = ja+amat.Stride, jb+bmat.Stride, jm+m.mat.Stride {
@@ -111,11 +111,11 @@ func (m *Dense) Sub(a, b Matrix) {
 	}
 
 	var restore func()
-	if m == aMat {
-		m, restore = m.isolatedWorkspace(aMat)
+	if m == aU {
+		m, restore = m.isolatedWorkspace(aU)
 		defer restore()
-	} else if m == bMat {
-		m, restore = m.isolatedWorkspace(bMat)
+	} else if m == bU {
+		m, restore = m.isolatedWorkspace(bU)
 		defer restore()
 	}
 
@@ -151,17 +151,17 @@ func (m *Dense) MulElem(a, b Matrix) {
 		panic(ErrShape)
 	}
 
-	aMat, _ := untranspose(a)
-	bMat, _ := untranspose(b)
+	aU, _ := untranspose(a)
+	bU, _ := untranspose(b)
 	m.reuseAs(ar, ac)
 
 	if arm, ok := a.(RawMatrixer); ok {
 		if brm, ok := b.(RawMatrixer); ok {
 			amat, bmat := arm.RawMatrix(), brm.RawMatrix()
-			if m != aMat {
+			if m != aU {
 				m.checkOverlap(amat)
 			}
-			if m != bMat {
+			if m != bU {
 				m.checkOverlap(bmat)
 			}
 			for ja, jb, jm := 0, 0, 0; ja < ar*amat.Stride; ja, jb, jm = ja+amat.Stride, jb+bmat.Stride, jm+m.mat.Stride {
@@ -174,11 +174,11 @@ func (m *Dense) MulElem(a, b Matrix) {
 	}
 
 	var restore func()
-	if m == aMat {
-		m, restore = m.isolatedWorkspace(aMat)
+	if m == aU {
+		m, restore = m.isolatedWorkspace(aU)
 		defer restore()
-	} else if m == bMat {
-		m, restore = m.isolatedWorkspace(bMat)
+	} else if m == bU {
+		m, restore = m.isolatedWorkspace(bU)
 		defer restore()
 	}
 
@@ -214,17 +214,17 @@ func (m *Dense) DivElem(a, b Matrix) {
 		panic(ErrShape)
 	}
 
-	aMat, _ := untranspose(a)
-	bMat, _ := untranspose(b)
+	aU, _ := untranspose(a)
+	bU, _ := untranspose(b)
 	m.reuseAs(ar, ac)
 
 	if arm, ok := a.(RawMatrixer); ok {
 		if brm, ok := b.(RawMatrixer); ok {
 			amat, bmat := arm.RawMatrix(), brm.RawMatrix()
-			if m != aMat {
+			if m != aU {
 				m.checkOverlap(amat)
 			}
-			if m != bMat {
+			if m != bU {
 				m.checkOverlap(bmat)
 			}
 			for ja, jb, jm := 0, 0, 0; ja < ar*amat.Stride; ja, jb, jm = ja+amat.Stride, jb+bmat.Stride, jm+m.mat.Stride {
@@ -237,11 +237,11 @@ func (m *Dense) DivElem(a, b Matrix) {
 	}
 
 	var restore func()
-	if m == aMat {
-		m, restore = m.isolatedWorkspace(aMat)
+	if m == aU {
+		m, restore = m.isolatedWorkspace(aU)
 		defer restore()
-	} else if m == bMat {
-		m, restore = m.isolatedWorkspace(bMat)
+	} else if m == bU {
+		m, restore = m.isolatedWorkspace(bU)
 		defer restore()
 	}
 
@@ -278,11 +278,11 @@ func (m *Dense) Inverse(a Matrix) error {
 		panic(ErrSquare)
 	}
 	m.reuseAs(a.Dims())
-	aMat, aTrans := untranspose(a)
-	switch rm := aMat.(type) {
+	aU, aTrans := untranspose(a)
+	switch rm := aU.(type) {
 	case RawMatrixer:
-		if m != aMat || aTrans {
-			if m == aMat || m.checkOverlap(rm.RawMatrix()) {
+		if m != aU || aTrans {
+			if m == aU || m.checkOverlap(rm.RawMatrix()) {
 				tmp := getWorkspace(r, c, false)
 				tmp.Copy(a)
 				m.Copy(tmp)
@@ -292,7 +292,7 @@ func (m *Dense) Inverse(a Matrix) error {
 			m.Copy(a)
 		}
 	default:
-		if m != aMat {
+		if m != aU {
 			m.Copy(a)
 		} else if aTrans {
 			// m and a share data so Copy cannot be used directly.
@@ -706,10 +706,10 @@ func (m *Dense) Scale(f float64, a Matrix) {
 
 	m.reuseAs(ar, ac)
 
-	aMat, aTrans := untranspose(a)
-	if rm, ok := aMat.(RawMatrixer); ok {
+	aU, aTrans := untranspose(a)
+	if rm, ok := aU.(RawMatrixer); ok {
 		amat := rm.RawMatrix()
-		if m == aMat || m.checkOverlap(amat) {
+		if m == aU || m.checkOverlap(amat) {
 			var restore func()
 			m, restore = m.isolatedWorkspace(a)
 			defer restore()
@@ -756,10 +756,10 @@ func (m *Dense) Apply(fn func(r, c int, v float64) float64, a Matrix) {
 
 	m.reuseAs(ar, ac)
 
-	aMat, aTrans := untranspose(a)
-	if rm, ok := aMat.(RawMatrixer); ok {
+	aU, aTrans := untranspose(a)
+	if rm, ok := aU.(RawMatrixer); ok {
 		amat := rm.RawMatrix()
-		if m == aMat || m.checkOverlap(amat) {
+		if m == aU || m.checkOverlap(amat) {
 			var restore func()
 			m, restore = m.isolatedWorkspace(a)
 			defer restore()

--- a/mat64/lu.go
+++ b/mat64/lu.go
@@ -245,12 +245,12 @@ func (m *Dense) SolveLU(lu *LU, trans bool, b Matrix) error {
 	}
 
 	m.reuseAs(n, bc)
-	bMat, _ := untranspose(b)
+	bU, _ := untranspose(b)
 	var restore func()
-	if m == bMat {
-		m, restore = m.isolatedWorkspace(bMat)
+	if m == bU {
+		m, restore = m.isolatedWorkspace(bU)
 		defer restore()
-	} else if rm, ok := bMat.(RawMatrixer); ok {
+	} else if rm, ok := bU.(RawMatrixer); ok {
 		m.checkOverlap(rm.RawMatrix())
 	}
 

--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -222,8 +222,8 @@ func Col(dst []float64, j int, a Matrix) []float64 {
 			panic(ErrRowLength)
 		}
 	}
-	aMat, aTrans := untranspose(a)
-	if rm, ok := aMat.(RawMatrixer); ok {
+	aU, aTrans := untranspose(a)
+	if rm, ok := aU.(RawMatrixer); ok {
 		m := rm.RawMatrix()
 		if aTrans {
 			copy(dst, m.Data[j*m.Stride:j*m.Stride+m.Cols])
@@ -256,8 +256,8 @@ func Row(dst []float64, i int, a Matrix) []float64 {
 			panic(ErrColLength)
 		}
 	}
-	aMat, aTrans := untranspose(a)
-	if rm, ok := aMat.(RawMatrixer); ok {
+	aU, aTrans := untranspose(a)
+	if rm, ok := aU.(RawMatrixer); ok {
 		m := rm.RawMatrix()
 		if aTrans {
 			blas64.Copy(c,
@@ -370,10 +370,10 @@ func Dot(a, b Matrix) float64 {
 		panic(ErrShape)
 	}
 	var sum float64
-	aMat, aTrans := untranspose(a)
-	bMat, bTrans := untranspose(b)
-	if rma, ok := aMat.(RawMatrixer); ok {
-		if rmb, ok := bMat.(RawMatrixer); ok {
+	aU, aTrans := untranspose(a)
+	bU, bTrans := untranspose(b)
+	if rma, ok := aU.(RawMatrixer); ok {
+		if rmb, ok := bU.(RawMatrixer); ok {
 			ra := rma.RawMatrix()
 			rb := rmb.RawMatrix()
 			if aTrans == bTrans {
@@ -410,10 +410,10 @@ func Equal(a, b Matrix) bool {
 	if ar != br || ac != bc {
 		return false
 	}
-	aMat, aTrans := untranspose(a)
-	bMat, bTrans := untranspose(b)
-	if rma, ok := aMat.(RawMatrixer); ok {
-		if rmb, ok := bMat.(RawMatrixer); ok {
+	aU, aTrans := untranspose(a)
+	bU, bTrans := untranspose(b)
+	if rma, ok := aU.(RawMatrixer); ok {
+		if rmb, ok := bU.(RawMatrixer); ok {
 			ra := rma.RawMatrix()
 			rb := rmb.RawMatrix()
 			if aTrans == bTrans {
@@ -436,8 +436,8 @@ func Equal(a, b Matrix) bool {
 			return true
 		}
 	}
-	if rma, ok := aMat.(RawSymmetricer); ok {
-		if rmb, ok := bMat.(RawSymmetricer); ok {
+	if rma, ok := aU.(RawSymmetricer); ok {
+		if rmb, ok := bU.(RawSymmetricer); ok {
 			ra := rma.RawSymmetric()
 			rb := rmb.RawSymmetric()
 			// Symmetric matrices are always upper and equal to their transpose.
@@ -451,8 +451,8 @@ func Equal(a, b Matrix) bool {
 			return true
 		}
 	}
-	if ra, ok := aMat.(*Vector); ok {
-		if rb, ok := bMat.(*Vector); ok {
+	if ra, ok := aU.(*Vector); ok {
+		if rb, ok := bU.(*Vector); ok {
 			// If the raw vectors are the same length they must either both be
 			// transposed or both not transposed (or have length 1).
 			for i := 0; i < ra.n; i++ {
@@ -482,10 +482,10 @@ func EqualApprox(a, b Matrix, epsilon float64) bool {
 	if ar != br || ac != bc {
 		return false
 	}
-	aMat, aTrans := untranspose(a)
-	bMat, bTrans := untranspose(b)
-	if rma, ok := aMat.(RawMatrixer); ok {
-		if rmb, ok := bMat.(RawMatrixer); ok {
+	aU, aTrans := untranspose(a)
+	bU, bTrans := untranspose(b)
+	if rma, ok := aU.(RawMatrixer); ok {
+		if rmb, ok := bU.(RawMatrixer); ok {
 			ra := rma.RawMatrix()
 			rb := rmb.RawMatrix()
 			if aTrans == bTrans {
@@ -508,8 +508,8 @@ func EqualApprox(a, b Matrix, epsilon float64) bool {
 			return true
 		}
 	}
-	if rma, ok := aMat.(RawSymmetricer); ok {
-		if rmb, ok := bMat.(RawSymmetricer); ok {
+	if rma, ok := aU.(RawSymmetricer); ok {
+		if rmb, ok := bU.(RawSymmetricer); ok {
 			ra := rma.RawSymmetric()
 			rb := rmb.RawSymmetric()
 			// Symmetric matrices are always upper and equal to their transpose.
@@ -523,8 +523,8 @@ func EqualApprox(a, b Matrix, epsilon float64) bool {
 			return true
 		}
 	}
-	if ra, ok := aMat.(*Vector); ok {
-		if rb, ok := bMat.(*Vector); ok {
+	if ra, ok := aU.(*Vector); ok {
+		if rb, ok := bU.(*Vector); ok {
 			// If the raw vectors are the same length they must either both be
 			// transposed or both not transposed (or have length 1).
 			for i := 0; i < ra.n; i++ {
@@ -563,8 +563,8 @@ func Max(a Matrix) float64 {
 		panic(ErrShape)
 	}
 	// Max(A) = Max(A^T)
-	aMat, _ := untranspose(a)
-	switch m := aMat.(type) {
+	aU, _ := untranspose(a)
+	switch m := aU.(type) {
 	case RawMatrixer:
 		rm := m.RawMatrix()
 		max := math.Inf(-1)
@@ -616,11 +616,11 @@ func Max(a Matrix) float64 {
 		}
 		return max
 	default:
-		r, c := aMat.Dims()
+		r, c := aU.Dims()
 		max := math.Inf(-1)
 		for i := 0; i < r; i++ {
 			for j := 0; j < c; j++ {
-				v := aMat.At(i, j)
+				v := aU.At(i, j)
 				if v > max {
 					max = v
 				}
@@ -638,8 +638,8 @@ func Min(a Matrix) float64 {
 		panic(ErrShape)
 	}
 	// Min(A) = Min(A^T)
-	aMat, _ := untranspose(a)
-	switch m := aMat.(type) {
+	aU, _ := untranspose(a)
+	switch m := aU.(type) {
 	case RawMatrixer:
 		rm := m.RawMatrix()
 		min := math.Inf(1)
@@ -691,11 +691,11 @@ func Min(a Matrix) float64 {
 		}
 		return min
 	default:
-		r, c := aMat.Dims()
+		r, c := aU.Dims()
 		min := math.Inf(1)
 		for i := 0; i < r; i++ {
 			for j := 0; j < c; j++ {
-				v := aMat.At(i, j)
+				v := aU.At(i, j)
 				if v < min {
 					min = v
 				}
@@ -719,9 +719,9 @@ func Norm(a Matrix, norm float64) float64 {
 	if r == 0 || c == 0 {
 		panic(ErrShape)
 	}
-	aMat, aTrans := untranspose(a)
+	aU, aTrans := untranspose(a)
 	var work []float64
-	switch rma := aMat.(type) {
+	switch rma := aU.(type) {
 	case RawMatrixer:
 		rm := rma.RawMatrix()
 		n := normLapack(norm, aTrans)
@@ -831,8 +831,8 @@ func Sum(a Matrix) float64 {
 
 	r, c := a.Dims()
 	var sum float64
-	aMat, _ := untranspose(a)
-	if rma, ok := aMat.(RawMatrixer); ok {
+	aU, _ := untranspose(a)
+	if rma, ok := aU.(RawMatrixer); ok {
 		rm := rma.RawMatrix()
 		for i := 0; i < rm.Rows; i++ {
 			for _, v := range rm.Data[i*rm.Stride : i*rm.Stride+rm.Cols] {
@@ -857,8 +857,8 @@ func Trace(a Matrix) float64 {
 		panic(ErrSquare)
 	}
 
-	aMat, _ := untranspose(a)
-	switch m := aMat.(type) {
+	aU, _ := untranspose(a)
+	switch m := aU.(type) {
 	case RawMatrixer:
 		rm := m.RawMatrix()
 		var t float64

--- a/mat64/solve.go
+++ b/mat64/solve.go
@@ -29,9 +29,9 @@ func (m *Dense) Solve(a, b Matrix) error {
 	m.reuseAs(ac, bc)
 
 	// TODO(btracey): Add special cases for SymDense, etc.
-	aMat, aTrans := untranspose(a)
-	bMat, bTrans := untranspose(b)
-	switch rma := aMat.(type) {
+	aU, aTrans := untranspose(a)
+	bU, bTrans := untranspose(b)
+	switch rma := aU.(type) {
 	case RawTriangular:
 		side := blas.Left
 		tA := blas.NoTrans
@@ -39,10 +39,10 @@ func (m *Dense) Solve(a, b Matrix) error {
 			tA = blas.Trans
 		}
 
-		switch rm := bMat.(type) {
+		switch rm := bU.(type) {
 		case RawMatrixer:
-			if m != bMat || bTrans {
-				if m == bMat || m.checkOverlap(rm.RawMatrix()) {
+			if m != bU || bTrans {
+				if m == bU || m.checkOverlap(rm.RawMatrix()) {
 					tmp := getWorkspace(br, bc, false)
 					tmp.Copy(b)
 					m.Copy(tmp)
@@ -52,7 +52,7 @@ func (m *Dense) Solve(a, b Matrix) error {
 				m.Copy(b)
 			}
 		default:
-			if m != bMat {
+			if m != bU {
 				m.Copy(b)
 			} else if bTrans {
 				// m and b share data so Copy cannot be used directly.


### PR DESCRIPTION
My editor (depending on its search mode) conflates aMat with amat, and a single character's case is not a good differentiator, so change Mat to U.

@btracey Please take a look.