### PR TITLE
cmat128: add conjugate transpose

### DIFF
--- a/cmat128/matrix.go
+++ b/cmat128/matrix.go
@@ -18,11 +18,19 @@ type Matrix interface {
 	// This method may be implemented using the Transpose type, which
 	// provides an implicit matrix transpose.
 	T() Matrix
+
+	// H returns the conjugate transpose of the Matrix. Whether H returns a copy of the
+	// underlying data is implementation dependent.
+	// This method may be implemented using the Conjugate type, which
+	// provides an implicit matrix conjugate transpose.
+	H() Matrix
 }
 
 var (
 	_ Matrix       = Transpose{}
+	_ Matrix       = Conjugate{}
 	_ Untransposer = Transpose{}
+	_ Untransposer = Conjugate{}
 )
 
 // Transpose is a type for performing an implicit matrix transpose. It implements
@@ -50,9 +58,49 @@ func (t Transpose) T() Matrix {
 	return t.Matrix
 }
 
+// H performs an implicit conjugate transpose.
+func (t Transpose) H() Matrix {
+	return Conjugate{t}
+}
+
 // Untranspose returns the Matrix field.
 func (t Transpose) Untranspose() Matrix {
 	return t.Matrix
+}
+
+// Transpose is a type for performing an implicit matrix transpose. It implements
+// the Matrix interface, returning values from the transpose of the matrix within.
+type Conjugate struct {
+	Matrix Matrix
+}
+
+// At returns the value of the element at row i and column j of the transposed
+// matrix, that is, row j and column i of the Matrix field.
+func (h Conjugate) At(i, j int) complex128 {
+	return h.Matrix.At(j, i) * complex(0, -1)
+}
+
+// Dims returns the dimensions of the transposed matrix. The number of rows returned
+// is the number of columns in the Matrix field, and the number of columns is
+// the number of rows in the Matrix field.
+func (h Conjugate) Dims() (r, c int) {
+	c, r = h.Matrix.Dims()
+	return r, c
+}
+
+// T performs an implicit transpose.
+func (h Conjugate) T() Matrix {
+	return Transpose{h}
+}
+
+// T performs an implicit conjugate transpose by returning the Matrix field.
+func (h Conjugate) H() Matrix {
+	return h.Matrix
+}
+
+// Untranspose returns the Matrix field.
+func (h Conjugate) Untranspose() Matrix {
+	return h.Matrix
 }
 
 // Untransposer is a type that can undo an implicit transpose.


### PR DESCRIPTION
This is complicated by the combinatorics, but I don't see a reasonable way around that, nor is there a way around that that can be made use of by blas or lapack even if we can, nor does a sensible program ever say `m.T().H()` or the other way around.

I think this may need further thought, so this is really to get the discussion started.

Fixes #283.

@btracey Please take a look.