### PR TITLE
mat64: remove unused interface checks and add Reseter check

### DIFF
--- a/mat64/vector.go
+++ b/mat64/vector.go
@@ -16,30 +16,7 @@ var (
 
 	_ Matrix = vector
 
-	// _ Cloner      = vector
-	// _ Viewer      = vector
-	// _ Subvectorer = vector
-
-	// _ Adder     = vector
-	// _ Suber     = vector
-	// _ Muler = vector
-	// _ Dotter    = vector
-	// _ ElemMuler = vector
-
-	// _ Scaler  = vector
-	// _ Applyer = vector
-
-	// _ Normer = vector
-	// _ Sumer  = vector
-
-	// _ Stacker   = vector
-	// _ Augmenter = vector
-
-	// _ Equaler       = vector
-	// _ ApproxEqualer = vector
-
-	// _ RawMatrixLoader = vector
-	// _ RawMatrixer     = vector
+	_ Reseter = vector
 )
 
 // Vector represents a column vector.


### PR DESCRIPTION
The dead checks are not valid and are never going to be valid under the current design approach, so delete them. *Vector is however a Reseter, so check that.

@btracey Please take a look.