### PR TITLE
mat64: special-case Dot for RawVectorers

### DIFF
--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -368,9 +368,17 @@ func Dot(a, b Matrix) float64 {
 	if r != rb || c != cb {
 		panic(matrix.ErrShape)
 	}
-	var sum float64
 	aU, aTrans := untranspose(a)
 	bU, bTrans := untranspose(b)
+	if rma, ok := aU.(RawVectorer); ok {
+		if rmb, ok := bU.(RawVectorer); ok {
+			if c > r {
+				r = c
+			}
+			return blas64.Dot(r, rma.RawVector(), rmb.RawVector())
+		}
+	}
+	var sum float64
 	if rma, ok := aU.(RawMatrixer); ok {
 		if rmb, ok := bU.(RawMatrixer); ok {
 			ra := rma.RawMatrix()


### PR DESCRIPTION
At the moment not for submission because oddly enough, this change makes fail one (and only one) test for the updated optimize.BFGS (that uses mat64 instead of floats). If I run the tests in optimize with `-tags noasm`, the test passes. I suspect that the assembler and Go versions of asm.Ddot have different order of the operations leading to different results and eventually to the failed test, something described for example in http://blog.nag.com/2011/02/wandering-precision.html. What would be a proper action? Loosen the tolerance for that test?