### PR TITLE
Use asm.Daxpy* functions

### DIFF
--- a/mat64/vector.go
+++ b/mat64/vector.go
@@ -179,7 +179,7 @@ func (v *Vector) AddScaledVec(a *Vector, alpha float64, b *Vector) {
 	default: // v <- a + alpha * b
 		if v.mat.Inc == 1 && a.mat.Inc == 1 && b.mat.Inc == 1 {
 			// Fast path for a common case.
-			asm.DaxpyUnitary(alpha, b.mat.Data, a.mat.Data, v.mat.Data)
+			asm.DaxpyUnitaryTo(v.mat.Data, alpha, b.mat.Data, a.mat.Data)
 			return
 		}
 		blas64.Copy(ar, a.mat, v.mat)

--- a/mat64/vector.go
+++ b/mat64/vector.go
@@ -190,10 +190,14 @@ func (v *Vector) AddVec(a, b *Vector) {
 
 	v.reuseAs(ar)
 
-	amat, bmat := a.RawVector(), b.RawVector()
-	for i := 0; i < v.n; i++ {
-		v.mat.Data[i*v.mat.Inc] = amat.Data[i*amat.Inc] + bmat.Data[i*bmat.Inc]
+	if v.mat.Inc == 1 && a.mat.Inc == 1 && b.mat.Inc == 1 {
+		// Fast path for a common case.
+		asm.DaxpyUnitaryTo(v.mat.Data, 1, b.mat.Data, a.mat.Data)
+		return
 	}
+	asm.DaxpyIncTo(v.mat.Data, uintptr(v.mat.Inc), 0,
+		1, b.mat.Data, a.mat.Data,
+		uintptr(ar), uintptr(b.mat.Inc), uintptr(a.mat.Inc), 0, 0)
 }
 
 // SubVec subtracts the vector b from a, placing the result in the receiver.

--- a/mat64/vector.go
+++ b/mat64/vector.go
@@ -211,10 +211,14 @@ func (v *Vector) SubVec(a, b *Vector) {
 
 	v.reuseAs(ar)
 
-	amat, bmat := a.RawVector(), b.RawVector()
-	for i := 0; i < v.n; i++ {
-		v.mat.Data[i*v.mat.Inc] = amat.Data[i*amat.Inc] - bmat.Data[i*bmat.Inc]
+	if v.mat.Inc == 1 && a.mat.Inc == 1 && b.mat.Inc == 1 {
+		// Fast path for a common case.
+		asm.DaxpyUnitaryTo(v.mat.Data, -1, b.mat.Data, a.mat.Data)
+		return
 	}
+	asm.DaxpyIncTo(v.mat.Data, uintptr(v.mat.Inc), 0,
+		-1, b.mat.Data, a.mat.Data,
+		uintptr(ar), uintptr(b.mat.Inc), uintptr(a.mat.Inc), 0, 0)
 }
 
 // MulElemVec performs element-wise multiplication of a and b, placing the result


### PR DESCRIPTION
Depends on gonum/internal#16

```
AddScaledVec10Inc1       13.6ns ± 0%  14.6ns ± 0%   +7.72%          (p=0.029 n=4+4)
AddScaledVec100Inc1      56.1ns ± 0%  45.3ns ± 0%  -19.25%          (p=0.029 n=4+4)
AddScaledVec1000Inc1      315ns ± 0%   271ns ± 0%  -13.97%          (p=0.029 n=4+4)
AddScaledVec10000Inc1    4.67µs ± 0%  4.98µs ± 0%   +6.52%          (p=0.029 n=4+4)
AddScaledVec100000Inc1   70.2µs ± 0%  69.9µs ± 0%   -0.40%          (p=0.029 n=4+4)
AddScaledVec10Inc2       55.5ns ± 0%  21.4ns ± 0%  -61.44%          (p=0.029 n=4+4)
AddScaledVec100Inc2       240ns ± 0%   117ns ± 0%  -51.25%          (p=0.029 n=4+4)
AddScaledVec1000Inc2     1.93µs ± 0%  1.05µs ± 0%  -45.46%          (p=0.029 n=4+4)
AddScaledVec10000Inc2    20.3µs ± 0%  12.2µs ± 0%  -39.95%          (p=0.029 n=4+4)
AddScaledVec100000Inc2    225µs ± 0%   125µs ± 0%  -44.65%          (p=0.029 n=4+4)
AddScaledVec10Inc20      55.8ns ± 0%  21.7ns ± 0%  -61.09%          (p=0.029 n=4+4)
AddScaledVec100Inc20      239ns ± 0%   117ns ± 0%  -51.05%          (p=0.029 n=4+4)
AddScaledVec1000Inc20    2.85µs ± 0%  2.36µs ± 0%  -17.31%          (p=0.029 n=4+4)
AddScaledVec10000Inc20   44.4µs ± 0%  40.5µs ± 0%   -8.80%          (p=0.029 n=4+4)
AddScaledVec100000Inc20  1.78ms ± 0%  1.43ms ± 0%  -19.33%          (p=0.029 n=4+4)
AddVec10Inc1             22.1ns ± 0%  12.3ns ± 0%  -44.34%          (p=0.029 n=4+4)
AddVec100Inc1             175ns ± 0%    42ns ± 0%  -76.06%          (p=0.029 n=4+4)
AddVec1000Inc1           1.60µs ± 0%  0.28µs ± 2%  -82.29%          (p=0.029 n=4+4)
AddVec10000Inc1          16.2µs ± 0%   5.0µs ± 0%  -69.25%          (p=0.029 n=4+4)
AddVec100000Inc1          161µs ± 0%    70µs ± 0%  -56.54%          (p=0.029 n=4+4)
AddVec10Inc2             22.1ns ± 0%  20.6ns ± 0%   -6.79%          (p=0.029 n=4+4)
AddVec100Inc2             175ns ± 0%   114ns ± 0%  -34.86%          (p=0.029 n=4+4)
AddVec1000Inc2           1.61µs ± 0%  1.05µs ± 0%  -34.55%          (p=0.029 n=4+4)
AddVec10000Inc2          18.2µs ± 0%  12.2µs ± 0%  -32.80%          (p=0.029 n=4+4)
AddVec100000Inc2          188µs ± 0%   125µs ± 0%  -33.45%          (p=0.029 n=4+4)
AddVec10Inc20            22.1ns ± 0%  20.7ns ± 0%   -6.33%          (p=0.029 n=4+4)
AddVec100Inc20            175ns ± 0%   115ns ± 0%  -34.38%          (p=0.029 n=4+4)
AddVec1000Inc20          2.71µs ± 1%  2.35µs ± 0%  -13.17%          (p=0.029 n=4+4)
AddVec10000Inc20         41.7µs ± 0%  40.5µs ± 0%   -2.91%          (p=0.029 n=4+4)
AddVec100000Inc20        1.74ms ± 1%  1.43ms ± 0%  -17.87%          (p=0.029 n=4+4)
SubVec10Inc1             22.7ns ± 0%  12.3ns ± 0%  -45.81%          (p=0.029 n=4+4)
SubVec100Inc1             175ns ± 0%    41ns ± 0%  -76.40%          (p=0.029 n=4+4)
SubVec1000Inc1           1.60µs ± 0%  0.27µs ± 0%  -83.30%          (p=0.029 n=4+4)
SubVec10000Inc1          16.3µs ± 0%   5.0µs ± 0%  -69.40%          (p=0.029 n=4+4)
SubVec100000Inc1          161µs ± 0%    70µs ± 0%  -56.62%          (p=0.029 n=4+4)
SubVec10Inc2             22.7ns ± 0%  20.6ns ± 0%   -9.03%          (p=0.029 n=4+4)
SubVec100Inc2             175ns ± 0%   114ns ± 1%  -34.71%          (p=0.029 n=4+4)
SubVec1000Inc2           1.61µs ± 0%  1.05µs ± 0%  -34.66%          (p=0.029 n=4+4)
SubVec10000Inc2          18.2µs ± 0%  12.2µs ± 0%  -32.99%          (p=0.029 n=4+4)
SubVec100000Inc2          188µs ± 0%   125µs ± 0%  -33.50%          (p=0.029 n=4+4)
SubVec10Inc20            22.7ns ± 0%  20.9ns ± 0%   -7.93%          (p=0.029 n=4+4)
SubVec100Inc20            175ns ± 0%   114ns ± 1%  -34.71%          (p=0.029 n=4+4)
SubVec1000Inc20          2.69µs ± 0%  2.35µs ± 0%  -12.61%          (p=0.029 n=4+4)
SubVec10000Inc20         42.0µs ± 0%  41.2µs ± 0%   -1.89%          (p=0.029 n=4+4)
SubVec100000Inc20        1.77ms ± 0%  1.44ms ± 0%  -18.68%          (p=0.029 n=4+4)
```