### PR TITLE
Rename (r,c) parameters to (i,j)

### DIFF
--- a/cmat128/matrix.go
+++ b/cmat128/matrix.go
@@ -9,9 +9,9 @@ type Matrix interface {
 	// Dims returns the dimensions of a Matrix.
 	Dims() (r, c int)
 
-	// At returns the value of a matrix element at (r, c). It will panic if r or c are
-	// out of bounds for the matrix.
-	At(r, c int) complex128
+	// At returns the value of a matrix element at row i, column j.
+	// It will panic if i or j are out of bounds for the matrix.
+	At(i, j int) complex128
 
 	// T returns the transpose of the Matrix. Whether T returns a copy of the
 	// underlying data is implementation dependent.

--- a/conv/conv.go
+++ b/conv/conv.go
@@ -49,15 +49,15 @@ func (m Complex) Dims() (r, c int) {
 	return m.r.Dims()
 }
 
-// At returns the element at row r, column c.
-func (m Complex) At(r, c int) complex128 {
+// At returns the element at row i, column j.
+func (m Complex) At(i, j int) complex128 {
 	if m.i == nil {
-		return complex(m.r.At(r, c), 0)
+		return complex(m.r.At(i, j), 0)
 	}
 	if m.r == nil {
-		return complex(0, m.i.At(r, c))
+		return complex(0, m.i.At(i, j))
 	}
-	return complex(m.r.At(r, c), m.i.At(r, c))
+	return complex(m.r.At(i, j), m.i.At(i, j))
 }
 
 // T performs an implicit transpose.
@@ -102,8 +102,8 @@ func NewReal(m cmat128.Matrix) mat64.Matrix {
 // Dims returns the number of rows and columns in the matrix.
 func (m Real) Dims() (r, c int) { return m.Matrix.Dims() }
 
-// At returns the element at row r, column c.
-func (m Real) At(r, c int) float64 { return real(m.Matrix.At(r, c)) }
+// At returns the element at row i, column j.
+func (m Real) At(i, j int) float64 { return real(m.Matrix.At(i, j)) }
 
 // T performs an implicit transpose.
 func (m Real) T() mat64.Matrix { return Real{m.Matrix.T()} }
@@ -123,8 +123,8 @@ func NewImag(m cmat128.Matrix) mat64.Matrix {
 // Dims returns the number of rows and columns in the matrix.
 func (m Imag) Dims() (r, c int) { return m.Matrix.Dims() }
 
-// At returns the element at row r, column c.
-func (m Imag) At(r, c int) float64 { return imag(m.Matrix.At(r, c)) }
+// At returns the element at row i, column j.
+func (m Imag) At(i, j int) float64 { return imag(m.Matrix.At(i, j)) }
 
 // T performs an implicit transpose.
 func (m Imag) T() mat64.Matrix { return Imag{m.Matrix.T()} }

--- a/mat64/dense_arithmetic.go
+++ b/mat64/dense_arithmetic.go
@@ -752,7 +752,7 @@ func (m *Dense) Scale(f float64, a Matrix) {
 // Apply applies the function fn to each of the elements of a, placing the
 // resulting matrix in the receiver. The function fn takes a row/column
 // index and element value and returns some function of that tuple.
-func (m *Dense) Apply(fn func(r, c int, v float64) float64, a Matrix) {
+func (m *Dense) Apply(fn func(i, j int, v float64) float64, a Matrix) {
 	ar, ac := a.Dims()
 
 	m.reuseAs(ar, ac)

--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -20,9 +20,9 @@ type Matrix interface {
 	// Dims returns the dimensions of a Matrix.
 	Dims() (r, c int)
 
-	// At returns the value of a matrix element at (r, c). It will panic if r or c are
-	// out of bounds for the matrix.
-	At(r, c int) float64
+	// At returns the value of a matrix element at row i, column j.
+	// It will panic if i or j are out of bounds for the matrix.
+	At(i, j int) float64
 
 	// T returns the transpose of the Matrix. Whether T returns a copy of the
 	// underlying data is implementation dependent.
@@ -80,9 +80,9 @@ type Untransposer interface {
 
 // Mutable is a matrix interface type that allows elements to be altered.
 type Mutable interface {
-	// Set alters the matrix element at (r, c) to v. It will panic if r or c are out of
-	// bounds for the matrix.
-	Set(r, c int, v float64)
+	// Set alters the matrix element at row i, column j to v.
+	// It will panic if i or j are out of bounds for the matrix.
+	Set(i, j int, v float64)
 
 	Matrix
 }


### PR DESCRIPTION
For the sake of consistency some remaining (r,c) indices that I had missed. PTAL