### PR TITLE
mat64: spelling fixes

### DIFF
--- a/mat64/cholesky.go
+++ b/mat64/cholesky.go
@@ -25,7 +25,7 @@ type Cholesky struct {
 
 // updateCond updates the condition number of the Cholesky decomposition. If
 // norm > 0, then that norm is used as the norm of the original matrix A, otherwise
-// the norm is estimated from the decompositon.
+// the norm is estimated from the decomposition.
 func (c *Cholesky) updateCond(norm float64) {
 	n := c.chol.mat.N
 	work := make([]float64, 3*n)
@@ -35,7 +35,7 @@ func (c *Cholesky) updateCond(norm float64) {
 		// The condition number is ||A|| || A^-1||, so this will underestimate
 		// the condition number somewhat.
 		// The norm of the original factorized matrix cannot be stored because of
-		// update possibilites.
+		// update possibilities.
 		unorm := lapack64.Lantr(matrix.CondNorm, c.chol.mat, work)
 		lnorm := lapack64.Lantr(matrix.CondNormTrans, c.chol.mat, work)
 		norm = unorm * lnorm

--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -186,7 +186,8 @@ func TestAtSet(t *testing.T) {
 		for i := 0; i < rows; i++ {
 			for j := 0; j < cols; j++ {
 				if m.At(i, j) != af[i][j] {
-					t.Errorf("unexpected value for At(%d, %d) for test %d: got: %v want: %v", m.At(i, j), af[i][j])
+					t.Errorf("unexpected value for At(%d, %d) for test %d: got: %v want: %v",
+						i, j, test, m.At(i, j), af[i][j])
 				}
 
 				v := float64(i * j)

--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -436,7 +436,7 @@ func TestGrow(t *testing.T) {
 	// Test grow uses existing data slice when matrix is zero size.
 	v.Reset()
 	p, l := &v.mat.Data[:1][0], cap(v.mat.Data)
-	*p = 1 // This element is at postion (-1, -1) relative to v and so should not be visible.
+	*p = 1 // This element is at position (-1, -1) relative to v and so should not be visible.
 	v = v.Grow(5, 5).(*Dense)
 	if &v.mat.Data[:1][0] != p {
 		t.Error("grow unexpectedly copied slice within cap limit")

--- a/mat64/eigen.go
+++ b/mat64/eigen.go
@@ -32,7 +32,7 @@ type Eigen struct {
 	ef eigenFactors
 }
 
-// Factorize computes the Eigen decompositon of the input square matrix a.
+// Factorize computes the Eigen decomposition of the input square matrix a.
 // The Eigen decomposition is defined as
 //  A = P * D * P^-1
 // where D is a diagonal matrix containing the eigenvalues of the matrix, and

--- a/mat64/list_test.go
+++ b/mat64/list_test.go
@@ -1112,7 +1112,7 @@ func testTwoInput(t *testing.T,
 						bSame = retranspose(bSame, receiver)
 					}
 					// Compute the real answer for this case. It is different
-					// from the inital answer since now a and b have the
+					// from the initial answer since now a and b have the
 					// same data.
 					zero = makeRandOf(wasZero, 0, 0)
 					method(zero, aSame, bSame)

--- a/mat64/lu.go
+++ b/mat64/lu.go
@@ -31,11 +31,11 @@ func (lu *LU) updateCond(norm float64) {
 	work := make([]float64, 4*n)
 	iwork := make([]int, n)
 	if norm < 0 {
-		// This is an approximation. By the defintion of a norm, ||AB|| <= ||A|| ||B||.
+		// This is an approximation. By the definition of a norm, ||AB|| <= ||A|| ||B||.
 		// The condition number is ||A|| || A^-1||, so this will underestimate
 		// the condition number somewhat.
 		// The norm of the original factorized matrix cannot be stored because of
-		// update possibilites, e.g. RankOne.
+		// update possibilities, e.g. RankOne.
 		u := lu.lu.asTriDense(n, blas.NonUnit, blas.Upper)
 		l := lu.lu.asTriDense(n, blas.Unit, blas.Lower)
 		unorm := lapack64.Lantr(matrix.CondNorm, u.mat, work)
@@ -233,7 +233,7 @@ func (m *Dense) Permutation(r int, swaps []int) {
 // It computes
 //  A * x = b if trans == false
 //  A^T * x = b if trans == true
-// In both cases, A is represeneted in LU factorized form, and the matrix x is
+// In both cases, A is represented in LU factorized form, and the matrix x is
 // stored into the receiver.
 //
 // If A is singular or near-singular a Condition error is returned. Please see
@@ -276,7 +276,7 @@ func (m *Dense) SolveLU(lu *LU, trans bool, b Matrix) error {
 // It computes
 //  A * x = b if trans == false
 //  A^T * x = b if trans == true
-// In both cases, A is represeneted in LU factorized form, and the matrix x is
+// In both cases, A is represented in LU factorized form, and the matrix x is
 // stored into the receiver.
 //
 // If A is singular or near-singular a Condition error is returned. Please see

--- a/mat64/lu_test.go
+++ b/mat64/lu_test.go
@@ -136,7 +136,7 @@ func TestSolveLU(t *testing.T) {
 		var got Dense
 		got.Mul(a, &x)
 		if !EqualApprox(&got, b, 1e-12) {
-			t.Error("Solve mismatch for non-singular matrix. n = %v, bc = %v.\nWant: %v\nGot: %v", n, bc, b, got)
+			t.Errorf("Solve mismatch for non-singular matrix. n = %v, bc = %v.\nWant: %v\nGot: %v", n, bc, b, got)
 		}
 	}
 	// TODO(btracey): Add testOneInput test when such a function exists.
@@ -184,7 +184,7 @@ func TestSolveLUVec(t *testing.T) {
 		var got Vector
 		got.MulVec(a, &x)
 		if !EqualApprox(&got, b, 1e-12) {
-			t.Error("Solve mismatch n = %v.\nWant: %v\nGot: %v", n, b, got)
+			t.Errorf("Solve mismatch n = %v.\nWant: %v\nGot: %v", n, b, got)
 		}
 	}
 	// TODO(btracey): Add testOneInput test when such a function exists.

--- a/mat64/product_test.go
+++ b/mat64/product_test.go
@@ -150,7 +150,7 @@ func TestProduct(t *testing.T) {
 				t.Fatal("unexpected number of expressions in brute force expression search")
 			}
 			if gotCost != wantCost {
-				t.Errorf("unexpected cost for chain dimensions: %+v got: %d want: %d\n%s",
+				t.Errorf("unexpected cost for chain dimensions: %+v got: %v want: %v\n%s",
 					dimensions, got, want, expr)
 			}
 		}


### PR DESCRIPTION
Found by goreportcard. Internal comments with English spelling are retained.