### PR TITLE
Add TriKind constant.

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -4,6 +4,16 @@
 
 package matrix
 
+// TriKind represents the triangularity of the matrix.
+type TriKind bool
+
+const (
+	// Upper specifies an upper triangular matrix.
+	Upper TriKind = true
+	// Lower specifies a lower triangular matrix.
+	Lower TriKind = false
+)
+
 // SVDKind specifies the treatment of singular vectors during the
 // factorization.
 type SVDKind int

--- a/mat64/index_no_bound_checks.go
+++ b/mat64/index_no_bound_checks.go
@@ -117,7 +117,7 @@ func (t *TriDense) At(i, j int) float64 {
 }
 
 func (t *TriDense) at(i, j int) float64 {
-	isUpper := t.isUpper()
+	isUpper := t.triKind()
 	if (isUpper && i > j) || (!isUpper && i < j) {
 		return 0
 	}

--- a/mat64/mul_test.go
+++ b/mat64/mul_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gonum/blas"
 	"github.com/gonum/blas/blas64"
 	"github.com/gonum/floats"
+	"github.com/gonum/matrix"
 )
 
 // TODO: Need to add tests where one is overwritten.
@@ -247,7 +248,7 @@ func (m *basicTriangular) T() Matrix {
 	return Transpose{m}
 }
 
-func (m *basicTriangular) Triangle() (int, bool) {
+func (m *basicTriangular) Triangle() (int, matrix.TriKind) {
 	return (*TriDense)(m).Triangle()
 }
 

--- a/mat64/triangular_test.go
+++ b/mat64/triangular_test.go
@@ -13,10 +13,10 @@ import (
 
 func TestNewTriangular(t *testing.T) {
 	for i, test := range []struct {
-		data  []float64
-		n     int
-		upper bool
-		mat   *TriDense
+		data []float64
+		n    int
+		kind matrix.TriKind
+		mat  *TriDense
 	}{
 		{
 			data: []float64{
@@ -24,8 +24,8 @@ func TestNewTriangular(t *testing.T) {
 				4, 5, 6,
 				7, 8, 9,
 			},
-			n:     3,
-			upper: true,
+			n:    3,
+			kind: matrix.Upper,
 			mat: &TriDense{
 				mat: blas64.Triangular{
 					N:      3,
@@ -38,7 +38,7 @@ func TestNewTriangular(t *testing.T) {
 			},
 		},
 	} {
-		tri := NewTriDense(test.n, test.upper, test.data)
+		tri := NewTriDense(test.n, test.kind, test.data)
 		rows, cols := tri.Dims()
 
 		if rows != test.n {
@@ -52,10 +52,10 @@ func TestNewTriangular(t *testing.T) {
 		}
 	}
 
-	for _, upper := range []bool{false, true} {
-		panicked, message := panics(func() { NewTriDense(3, upper, []float64{1, 2}) })
+	for _, kind := range []matrix.TriKind{matrix.Lower, matrix.Upper} {
+		panicked, message := panics(func() { NewTriDense(3, kind, []float64{1, 2}) })
 		if !panicked || message != matrix.ErrShape.Error() {
-			t.Errorf("expected panic for invalid data slice length for upper=%t", upper)
+			t.Errorf("expected panic for invalid data slice length for upper=%t", kind)
 		}
 	}
 }
@@ -238,13 +238,13 @@ func TestTriTriDenseCopy(t *testing.T) {
 }
 
 func TestTriInverse(t *testing.T) {
-	for _, upper := range []bool{true, false} {
+	for _, kind := range []matrix.TriKind{matrix.Upper, matrix.Lower} {
 		for _, n := range []int{1, 3, 5, 9} {
 			data := make([]float64, n*n)
 			for i := range data {
 				data[i] = rand.NormFloat64()
 			}
-			a := NewTriDense(n, upper, data)
+			a := NewTriDense(n, kind, data)
 			var tr TriDense
 			err := tr.InverseTri(a)
 			if err != nil {


### PR DESCRIPTION
This change modifies the signature of NewTriDense(n int, upper bool, data []float64) to NewTriDense(n int, kind matrix.TriKind, data []float64). This increases the legibility of calls to NewTriDense as it is now written as mat64.NewTriDense(n, matrix.Upper, nil) rather than needing to memorize if upper triangular is true or false