### PR TITLE
Changed matrix.Vector to be a type alias of blas64.Vector

### DIFF
--- a/mat64/cholesky.go
+++ b/mat64/cholesky.go
@@ -121,8 +121,8 @@ func (v *Vector) SolveCholeskyVec(chol *Cholesky, b *Vector) error {
 	if v != b {
 		v.CopyVec(b)
 	}
-	blas64.Trsv(blas.Trans, chol.chol.mat, v.mat)
-	blas64.Trsv(blas.NoTrans, chol.chol.mat, v.mat)
+	blas64.Trsv(blas.Trans, chol.chol.mat, blas64.Vector(*v))
+	blas64.Trsv(blas.NoTrans, chol.chol.mat, blas64.Vector(*v))
 	if chol.cond > matrix.ConditionTolerance {
 		return matrix.Condition(chol.cond)
 	}

--- a/mat64/dense.go
+++ b/mat64/dense.go
@@ -168,11 +168,8 @@ func (m *Dense) ColView(j int) *Vector {
 		panic(matrix.ErrColAccess)
 	}
 	return &Vector{
-		mat: blas64.Vector{
-			Inc:  m.mat.Stride,
-			Data: m.mat.Data[j : (m.mat.Rows-1)*m.mat.Stride+j+1],
-		},
-		n: m.mat.Rows,
+		Inc:  m.mat.Stride,
+		Data: m.mat.Data[j : (m.mat.Rows-1)*m.mat.Stride+j+1],
 	}
 }
 
@@ -214,11 +211,8 @@ func (m *Dense) RowView(i int) *Vector {
 		panic(matrix.ErrRowAccess)
 	}
 	return &Vector{
-		mat: blas64.Vector{
-			Inc:  1,
-			Data: m.mat.Data[i*m.mat.Stride : i*m.mat.Stride+m.mat.Cols],
-		},
-		n: m.mat.Cols,
+		Inc:  1,
+		Data: m.mat.Data[i*m.mat.Stride : i*m.mat.Stride+m.mat.Cols],
 	}
 }
 

--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -5,6 +5,7 @@
 package mat64
 
 import (
+	"fmt"
 	"math"
 	"math/rand"
 	"reflect"
@@ -319,6 +320,7 @@ func TestRowColView(t *testing.T) {
 		for j := 0; j < cols; j++ {
 			vc := m.ColView(j)
 			if vc.Len() != rows {
+				fmt.Println(*vc)
 				t.Errorf("unexpected number of rows: got: %d want: %d", vc.Len(), rows)
 			}
 			for i := 0; i < rows; i++ {

--- a/mat64/index_no_bound_checks.go
+++ b/mat64/index_no_bound_checks.go
@@ -43,7 +43,7 @@ func (m *Dense) set(i, j int, v float64) {
 // At returns the element at row i.
 // It panics if i is out of bounds or if j is not zero.
 func (v *Vector) At(i, j int) float64 {
-	if i < 0 || i >= v.n {
+	if i < 0 || i >= v.Len() {
 		panic(matrix.ErrRowAccess)
 	}
 	if j != 0 {
@@ -53,20 +53,20 @@ func (v *Vector) At(i, j int) float64 {
 }
 
 func (v *Vector) at(i int) float64 {
-	return v.mat.Data[i*v.mat.Inc]
+	return v.Data[i*v.Inc]
 }
 
 // SetVec sets the element at row i to the value val.
 // It panics if i is out of bounds.
 func (v *Vector) SetVec(i int, val float64) {
-	if i < 0 || i >= v.n {
+	if i < 0 || i >= v.Len() {
 		panic(matrix.ErrVectorAccess)
 	}
 	v.setVec(i, val)
 }
 
 func (v *Vector) setVec(i int, val float64) {
-	v.mat.Data[i*v.mat.Inc] = val
+	v.Data[i*v.Inc] = val
 }
 
 // At returns the element at row i and column j.

--- a/mat64/inner.go
+++ b/mat64/inner.go
@@ -40,32 +40,32 @@ func Inner(x *Vector, A Matrix, y *Vector) float64 {
 		for i := 0; i < x.Len(); i++ {
 			xi := x.at(i)
 			if xi != 0 {
-				if y.mat.Inc == 1 {
+				if y.Inc == 1 {
 					sum += xi * asm.DdotUnitary(
 						bmat.Data[i*bmat.Stride+i:i*bmat.Stride+n],
-						y.mat.Data[i:],
+						y.Data[i:],
 					)
 				} else {
 					sum += xi * asm.DdotInc(
 						bmat.Data[i*bmat.Stride+i:i*bmat.Stride+n],
-						y.mat.Data[i*y.mat.Inc:], uintptr(n-i),
-						1, uintptr(y.mat.Inc),
+						y.Data[i*y.Inc:], uintptr(n-i),
+						1, uintptr(y.Inc),
 						0, 0,
 					)
 				}
 			}
 			yi := y.at(i)
 			if i != n-1 && yi != 0 {
-				if x.mat.Inc == 1 {
+				if x.Inc == 1 {
 					sum += yi * asm.DdotUnitary(
 						bmat.Data[i*bmat.Stride+i+1:i*bmat.Stride+n],
-						x.mat.Data[i+1:],
+						x.Data[i+1:],
 					)
 				} else {
 					sum += yi * asm.DdotInc(
 						bmat.Data[i*bmat.Stride+i+1:i*bmat.Stride+n],
-						x.mat.Data[(i+1)*x.mat.Inc:], uintptr(n-i-1),
-						1, uintptr(x.mat.Inc),
+						x.Data[(i+1)*x.Inc:], uintptr(n-i-1),
+						1, uintptr(x.Inc),
 						0, 0,
 					)
 				}
@@ -76,16 +76,16 @@ func Inner(x *Vector, A Matrix, y *Vector) float64 {
 		for i := 0; i < x.Len(); i++ {
 			xi := x.at(i)
 			if xi != 0 {
-				if y.mat.Inc == 1 {
+				if y.Inc == 1 {
 					sum += xi * asm.DdotUnitary(
 						bmat.Data[i*bmat.Stride:i*bmat.Stride+n],
-						y.mat.Data,
+						y.Data,
 					)
 				} else {
 					sum += xi * asm.DdotInc(
 						bmat.Data[i*bmat.Stride:i*bmat.Stride+n],
-						y.mat.Data, uintptr(n),
-						1, uintptr(y.mat.Inc),
+						y.Data, uintptr(n),
+						1, uintptr(y.Inc),
 						0, 0,
 					)
 				}

--- a/mat64/inner_test.go
+++ b/mat64/inner_test.go
@@ -129,31 +129,28 @@ func TestInnerSym(t *testing.T) {
 
 func makeVectorInc(inc int, f []float64) *Vector {
 	v := &Vector{
-		n: len(f),
-		mat: blas64.Vector{
-			Inc:  inc,
-			Data: make([]float64, (len(f)-1)*inc+1),
-		},
+		Inc:  inc,
+		Data: make([]float64, (len(f)-1)*inc+1),
 	}
 
 	// Contaminate backing data in all positions...
 	const base = 100
-	for i := range v.mat.Data {
-		v.mat.Data[i] = float64(i + base)
+	for i := range v.Data {
+		v.Data[i] = float64(i + base)
 	}
 
 	// then write real elements.
 	for i := range f {
-		v.mat.Data[i*inc] = f[i]
+		v.Data[i*inc] = f[i]
 	}
 	return v
 }
 
 func benchmarkInner(b *testing.B, m, n int) {
 	x := NewVector(m, nil)
-	randomSlice(x.mat.Data)
+	randomSlice(x.Data)
 	y := NewVector(n, nil)
-	randomSlice(y.mat.Data)
+	randomSlice(y.Data)
 	data := make([]float64, m*n)
 	randomSlice(data)
 	mat := &Dense{mat: blas64.General{Rows: m, Cols: n, Stride: n, Data: data}, capRows: m, capCols: n}

--- a/mat64/list_test.go
+++ b/mat64/list_test.go
@@ -266,15 +266,12 @@ func makeRandOf(a Matrix, m, n int) Matrix {
 		}
 		length := m
 		inc := 1
-		if t.mat.Inc != 0 {
-			inc = t.mat.Inc
+		if t.Inc != 0 {
+			inc = t.Inc
 		}
 		mat := &Vector{
-			mat: blas64.Vector{
-				Inc:  inc,
-				Data: make([]float64, inc*(length-1)+1),
-			},
-			n: length,
+			Inc:  inc,
+			Data: make([]float64, inc*(length-1)+1),
 		}
 		for i := 0; i < length; i++ {
 			mat.SetVec(i, rand.NormFloat64())
@@ -364,13 +361,10 @@ func makeCopyOf(a Matrix) Matrix {
 		return returnAs(m, t)
 	case *Vector:
 		m := &Vector{
-			mat: blas64.Vector{
-				Inc:  t.mat.Inc,
-				Data: make([]float64, t.mat.Inc*(t.n-1)+1),
-			},
-			n: t.n,
+			Inc:  t.Inc,
+			Data: make([]float64, t.Inc*(t.Len()-1)+1),
 		}
-		copy(m.mat.Data, t.mat.Data)
+		copy(m.Data, t.Data)
 		return m
 	}
 }
@@ -478,7 +472,7 @@ func underlyingData(a Matrix) []float64 {
 	case *SymDense:
 		return t.mat.Data
 	case *Vector:
-		return t.mat.Data
+		return t.Data
 	}
 }
 
@@ -489,7 +483,7 @@ var testMatrices = []Matrix{
 	NewTriDense(0, true, nil),
 	NewTriDense(0, false, nil),
 	NewVector(0, nil),
-	&Vector{mat: blas64.Vector{Inc: 10}},
+	&Vector{Inc: 10},
 	&basicMatrix{},
 	&basicSymmetric{},
 	&basicTriangular{mat: blas64.Triangular{Uplo: blas.Upper}},
@@ -501,7 +495,7 @@ var testMatrices = []Matrix{
 	Transpose{NewTriDense(0, false, nil)},
 	TransposeTri{NewTriDense(0, false, nil)},
 	Transpose{NewVector(0, nil)},
-	Transpose{&Vector{mat: blas64.Vector{Inc: 10}}},
+	Transpose{&Vector{Inc: 10}},
 	Transpose{&basicMatrix{}},
 	Transpose{&basicSymmetric{}},
 	Transpose{&basicTriangular{mat: blas64.Triangular{Uplo: blas.Upper}}},

--- a/mat64/lu.go
+++ b/mat64/lu.go
@@ -303,8 +303,8 @@ func (v *Vector) SolveLUVec(lu *LU, trans bool, b *Vector) error {
 	vMat := blas64.General{
 		Rows:   n,
 		Cols:   1,
-		Stride: v.mat.Inc,
-		Data:   v.mat.Data,
+		Stride: v.Inc,
+		Data:   v.Data,
 	}
 	t := blas.NoTrans
 	if trans {

--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -438,8 +438,8 @@ func Equal(a, b Matrix) bool {
 		if rb, ok := bU.(*Vector); ok {
 			// If the raw vectors are the same length they must either both be
 			// transposed or both not transposed (or have length 1).
-			for i := 0; i < ra.n; i++ {
-				if ra.mat.Data[i*ra.mat.Inc] != rb.mat.Data[i*rb.mat.Inc] {
+			for i := 0; i < ra.Len(); i++ {
+				if ra.Data[i*ra.Inc] != rb.Data[i*rb.Inc] {
 					return false
 				}
 			}
@@ -510,8 +510,8 @@ func EqualApprox(a, b Matrix, epsilon float64) bool {
 		if rb, ok := bU.(*Vector); ok {
 			// If the raw vectors are the same length they must either both be
 			// transposed or both not transposed (or have length 1).
-			for i := 0; i < ra.n; i++ {
-				if !floats.EqualWithinAbsOrRel(ra.mat.Data[i*ra.mat.Inc], rb.mat.Data[i*rb.mat.Inc], epsilon, epsilon) {
+			for i := 0; i < ra.Len(); i++ {
+				if !floats.EqualWithinAbsOrRel(ra.Data[i*ra.Inc], rb.Data[i*rb.Inc], epsilon, epsilon) {
 					return false
 				}
 			}
@@ -727,23 +727,22 @@ func Norm(a Matrix, norm float64) float64 {
 		}
 		return lapack64.Lansy(n, rm, work)
 	case *Vector:
-		rv := rma.RawVector()
 		switch norm {
 		default:
 			panic("unreachable")
 		case 1:
 			if aTrans {
-				imax := blas64.Iamax(rma.n, rv)
+				imax := blas64.Iamax(rma.Len(), blas64.Vector(*rma))
 				return math.Abs(rma.At(imax, 0))
 			}
-			return blas64.Asum(rma.n, rv)
+			return blas64.Asum(rma.Len(), blas64.Vector(*rma))
 		case 2:
-			return blas64.Nrm2(rma.n, rv)
+			return blas64.Nrm2(rma.Len(), blas64.Vector(*rma))
 		case math.Inf(1):
 			if aTrans {
-				return blas64.Asum(rma.n, rv)
+				return blas64.Asum(rma.Len(), blas64.Vector(*rma))
 			}
-			imax := blas64.Iamax(rma.n, rv)
+			imax := blas64.Iamax(rma.Len(), blas64.Vector(*rma))
 			return math.Abs(rma.At(imax, 0))
 		}
 	}

--- a/mat64/pool.go
+++ b/mat64/pool.go
@@ -67,10 +67,10 @@ func init() {
 			}}
 		}
 		poolVec[i].New = func() interface{} {
-			return &Vector{mat: blas64.Vector{
+			return &Vector{
 				Inc:  1,
 				Data: make([]float64, l),
-			}}
+			}
 		}
 	}
 }
@@ -128,11 +128,10 @@ func putWorkspaceSym(s *SymDense) {
 func getWorkspaceVec(n int, clear bool) *Vector {
 	l := uint64(n)
 	v := poolVec[bits(l)].Get().(*Vector)
-	v.mat.Data = v.mat.Data[:l]
+	v.Data = v.Data[:l]
 	if clear {
-		zero(v.mat.Data)
+		zero(v.Data)
 	}
-	v.n = n
 	return v
 }
 
@@ -140,5 +139,5 @@ func getWorkspaceVec(n int, clear bool) *Vector {
 // workspace pool. putWorkspaceVec must not be called with a matrix
 // where references to the underlying data slice has been kept.
 func putWorkspaceVec(v *Vector) {
-	poolVec[bits(uint64(cap(v.mat.Data)))].Put(v)
+	poolVec[bits(uint64(cap(v.Data)))].Put(v)
 }

--- a/mat64/qr.go
+++ b/mat64/qr.go
@@ -216,14 +216,15 @@ func (v *Vector) SolveQRVec(qr *QR, trans bool, b *Vector) error {
 
 // vecAsDense returns the vector as a Dense matrix with the same underlying data.
 func vecAsDense(v *Vector) *Dense {
+	r := v.Len()
 	return &Dense{
 		mat: blas64.General{
-			Rows:   v.n,
+			Rows:   r,
 			Cols:   1,
-			Stride: v.mat.Inc,
-			Data:   v.mat.Data,
+			Stride: v.Inc,
+			Data:   v.Data,
 		},
-		capRows: v.n,
+		capRows: r,
 		capCols: 1,
 	}
 }

--- a/mat64/shadow.go
+++ b/mat64/shadow.go
@@ -149,22 +149,21 @@ func (t *TriDense) checkOverlap(a blas64.Triangular) bool {
 }
 
 func (v *Vector) checkOverlap(a blas64.Vector) bool {
-	mat := v.mat
-	if cap(mat.Data) == 0 || cap(a.Data) == 0 {
+	if cap(v.Data) == 0 || cap(a.Data) == 0 {
 		return false
 	}
 
-	off := offset(mat.Data[:1], a.Data[:1])
+	off := offset(v.Data[:1], a.Data[:1])
 
 	if off == 0 {
 		// At least one element overlaps.
-		if mat.Inc == a.Inc && len(mat.Data) == len(a.Data) {
+		if v.Inc == a.Inc && len(v.Data) == len(a.Data) {
 			panic(regionIdentity)
 		}
 		panic(regionOverlap)
 	}
 
-	if off > 0 && len(mat.Data) <= off {
+	if off > 0 && len(v.Data) <= off {
 		// We know v is completely before a.
 		return false
 	}
@@ -173,12 +172,12 @@ func (v *Vector) checkOverlap(a blas64.Vector) bool {
 		return false
 	}
 
-	if mat.Inc != a.Inc {
+	if v.Inc != a.Inc {
 		// Too hard, so assume the worst.
 		panic(mismatchedStrides)
 	}
 
-	if mat.Inc == 1 || off&mat.Inc == 0 {
+	if v.Inc == 1 || off&v.Inc == 0 {
 		panic(regionOverlap)
 	}
 	return false

--- a/mat64/symmetric.go
+++ b/mat64/symmetric.go
@@ -209,7 +209,7 @@ func (s *SymDense) SymRankOne(a Symmetric, alpha float64, x *Vector) {
 	if s != a {
 		s.CopySym(a)
 	}
-	blas64.Syr(alpha, x.mat, s.mat)
+	blas64.Syr(alpha, blas64.Vector(*x), s.mat)
 }
 
 // SymRankK performs a symmetric rank-k update to the matrix a and stores the
@@ -296,7 +296,7 @@ func (s *SymDense) RankTwo(a Symmetric, alpha float64, x, y *Vector) {
 	if s != a {
 		w.CopySym(a)
 	}
-	blas64.Syr2(alpha, x.mat, y.mat, w.mat)
+	blas64.Syr2(alpha, blas64.Vector(*x), blas64.Vector(*y), w.mat)
 	*s = w
 	return
 }

--- a/mat64/vector_test.go
+++ b/mat64/vector_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/gonum/blas/blas64"
 	"github.com/gonum/matrix"
 )
 
@@ -19,22 +18,16 @@ func TestNewVector(t *testing.T) {
 			n:    3,
 			data: []float64{4, 5, 6},
 			vector: &Vector{
-				mat: blas64.Vector{
-					Data: []float64{4, 5, 6},
-					Inc:  1,
-				},
-				n: 3,
+				Data: []float64{4, 5, 6},
+				Inc:  1,
 			},
 		},
 		{
 			n:    3,
 			data: nil,
 			vector: &Vector{
-				mat: blas64.Vector{
-					Data: []float64{0, 0, 0},
-					Inc:  1,
-				},
-				n: 3,
+				Data: []float64{0, 0, 0},
+				Inc:  1,
 			},
 		},
 	} {
@@ -58,25 +51,19 @@ func TestVectorAtSet(t *testing.T) {
 	}{
 		{
 			vector: &Vector{
-				mat: blas64.Vector{
-					Data: []float64{0, 1, 2},
-					Inc:  1,
-				},
-				n: 3,
+				Data: []float64{0, 1, 2},
+				Inc:  1,
 			},
 		},
 		{
 			vector: &Vector{
-				mat: blas64.Vector{
-					Data: []float64{0, 10, 10, 1, 10, 10, 2},
-					Inc:  3,
-				},
-				n: 3,
+				Data: []float64{0, 10, 10, 1, 10, 10, 2},
+				Inc:  3,
 			},
 		},
 	} {
 		v := test.vector
-		n := test.vector.n
+		n := test.vector.Len()
 
 		for _, row := range []int{-1, n} {
 			panicked, message := panics(func() { v.At(row, 0) })
@@ -184,14 +171,14 @@ func TestVectorScale(t *testing.T) {
 	} {
 		var v Vector
 		v.ScaleVec(test.alpha, test.a)
-		if !reflect.DeepEqual(v.RawVector(), test.want.RawVector()) {
-			t.Errorf("test %d: unexpected result for v = alpha * a: got: %v want: %v", i, v.RawVector(), test.want.RawVector())
+		if !reflect.DeepEqual(v, *test.want) {
+			t.Errorf("test %d: unexpected result for v = alpha * a: got: %v want: %v", i, v, test.want)
 		}
 
 		v.CopyVec(test.a)
 		v.ScaleVec(test.alpha, &v)
-		if !reflect.DeepEqual(v.RawVector(), test.want.RawVector()) {
-			t.Errorf("test %d: unexpected result for v = alpha * v: got: %v want: %v", i, v.RawVector(), test.want.RawVector())
+		if !reflect.DeepEqual(v, *test.want) {
+			t.Errorf("test %d: unexpected result for v = alpha * v: got: %v want: %v", i, v, test.want)
 		}
 	}
 
@@ -251,8 +238,8 @@ func TestVectorAdd(t *testing.T) {
 	} {
 		var v Vector
 		v.AddVec(test.a, test.b)
-		if !reflect.DeepEqual(v.RawVector(), test.want.RawVector()) {
-			t.Errorf("unexpected result for test %d: got: %v want: %v", i, v.RawVector(), test.want.RawVector())
+		if !reflect.DeepEqual(v, *test.want) {
+			t.Errorf("unexpected result for test %d: got: %v want: %v", i, v, test.want)
 		}
 	}
 }
@@ -280,8 +267,8 @@ func TestVectorSub(t *testing.T) {
 	} {
 		var v Vector
 		v.SubVec(test.a, test.b)
-		if !reflect.DeepEqual(v.RawVector(), test.want.RawVector()) {
-			t.Errorf("unexpected result for test %d: got: %v want: %v", i, v.RawVector(), test.want.RawVector())
+		if !reflect.DeepEqual(v, *test.want) {
+			t.Errorf("unexpected result for test %d: got: %v want: %v", i, v, test.want)
 		}
 	}
 }
@@ -309,8 +296,8 @@ func TestVectorMulElem(t *testing.T) {
 	} {
 		var v Vector
 		v.MulElemVec(test.a, test.b)
-		if !reflect.DeepEqual(v.RawVector(), test.want.RawVector()) {
-			t.Errorf("unexpected result for test %d: got: %v want: %v", i, v.RawVector(), test.want.RawVector())
+		if !reflect.DeepEqual(v, *test.want) {
+			t.Errorf("unexpected result for test %d: got: %v want: %v", i, v, test.want)
 		}
 	}
 }
@@ -338,8 +325,8 @@ func TestVectorDivElem(t *testing.T) {
 	} {
 		var v Vector
 		v.DivElemVec(test.a, test.b)
-		if !reflect.DeepEqual(v.RawVector(), test.want.RawVector()) {
-			t.Errorf("unexpected result for test %d: got: %v want: %v", i, v.RawVector(), test.want.RawVector())
+		if !reflect.DeepEqual(v, *test.want) {
+			t.Errorf("unexpected result for test %d: got: %v want: %v", i, v, test.want)
 		}
 	}
 }
@@ -454,10 +441,7 @@ func randVector(size, inc int, rho float64, rnd func() float64) *Vector {
 		}
 	}
 	return &Vector{
-		mat: blas64.Vector{
-			Inc:  inc,
-			Data: data,
-		},
-		n: size,
+		Inc:  inc,
+		Data: data,
 	}
 }


### PR DESCRIPTION
This is a proof of concept and I would not dig deeply into the changes
immediately, because if you don’t like the premise then the rest is
irrelevant.

At first I was thinking about adding a BinaryMarshal and
BinaryUnmarshal to matrix.Vector to satisfy #337, but those methods are
supposed to be composable, so I thought maybe it would make sense to
add to blas64.Vector and then call from matrix.

But I’m really lazy and I’d rather not have to call it from matrix at
all.  By aliasing the type of matrix.Vector to blas64.Vector, it will
automatically pick up any methods from the original type.  As a bonus,
calling blas funcs on matrix vectors is a snap.  I imagine this
approach could be extended to other matrix types, and would allow
library callers to get down to a lower implementation level whenever
they want to take the gloves off.

(github autocorrect keeps trying to call this “composable" idea
“compostable”, hopefully you won’t feel the same…)