### PR TITLE
mat64: implement Binary(Un)Marshaler for Vector

### DIFF
--- a/mat64/io.go
+++ b/mat64/io.go
@@ -5,14 +5,182 @@
 package mat64
 
 import (
+	"bytes"
 	"encoding/binary"
+	"errors"
+)
+
+const (
+	// maxLen is the biggest slice/array len one can create on a 32/64b platform.
+	maxLen = int64(int(^uint(0) >> 1))
 )
 
 var (
-	littleEndian  = binary.LittleEndian
-	bigEndian     = binary.BigEndian
-	defaultEndian = littleEndian
-
 	sizeInt64   = binary.Size(int64(0))
 	sizeFloat64 = binary.Size(float64(0))
+
+	errTooBig    = errors.New("mat64: resulting data slice too big")
+	errBadBuffer = errors.New("mat64: data buffer size mismatch")
+	errBadSize   = errors.New("mat64: invalid dimension")
 )
+
+// MarshalBinary encodes the receiver into a binary form and returns the result.
+//
+// Dense is little-endian encoded as follows:
+//   0 -  7  number of rows    (int64)
+//   8 - 15  number of columns (int64)
+//  16 - ..  matrix data elements (float64)
+//           [0,0] [0,1] ... [0,ncols-1]
+//           [1,0] [1,1] ... [1,ncols-1]
+//           ...
+//           [nrows-1,0] ... [nrows-1,ncols-1]
+func (m Dense) MarshalBinary() ([]byte, error) {
+	bufLen := int64(m.mat.Rows)*int64(m.mat.Cols)*int64(sizeFloat64) + 2*int64(sizeInt64)
+	if bufLen <= 0 {
+		// bufLen is too big and has wrapped around.
+		return nil, errTooBig
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, bufLen))
+	err := binary.Write(buf, binary.LittleEndian, int64(m.mat.Rows))
+	if err != nil {
+		return nil, err
+	}
+	err = binary.Write(buf, binary.LittleEndian, int64(m.mat.Cols))
+	if err != nil {
+		return nil, err
+	}
+
+	r, c := m.Dims()
+	for i := 0; i < r; i++ {
+		for j := 0; j < c; j++ {
+			err = binary.Write(buf, binary.LittleEndian, m.at(i, j))
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalBinary decodes the binary form into the receiver.
+// It panics if the receiver is a non-zero Dense matrix.
+//
+// See MarshalBinary for the on-disk layout.
+//
+// Limited checks on the validity of the binary input are performed:
+//  - matrix.ErrShape is returned if the number of rows or columns is negative,
+//  - an error is returned if the resulting Dense matrix is too
+//  big for the current architecture (e.g. a 16GB matrix written by a
+//  64b application and read back from a 32b application.)
+// UnmarshalBinary does not limit the size of the unmarshaled matrix, and so
+// it should not be used on untrusted data.
+func (m *Dense) UnmarshalBinary(data []byte) error {
+	if !m.isZero() {
+		panic("mat64: unmarshal into non-zero matrix")
+	}
+
+	buf := bytes.NewReader(data)
+	var rows int64
+	err := binary.Read(buf, binary.LittleEndian, &rows)
+	if err != nil {
+		return err
+	}
+	var cols int64
+	err = binary.Read(buf, binary.LittleEndian, &cols)
+	if err != nil {
+		return err
+	}
+
+	if rows < 0 || cols < 0 {
+		return errBadSize
+	}
+
+	size := rows * cols
+	if int(size) < 0 || size > maxLen {
+		return errTooBig
+	}
+
+	if len(data) != int(size)*sizeFloat64+2*sizeInt64 {
+		return errBadBuffer
+	}
+
+	m.mat.Rows = int(rows)
+	m.mat.Cols = int(cols)
+	m.mat.Stride = int(cols)
+	m.capRows = int(rows)
+	m.capCols = int(cols)
+	m.mat.Data = use(m.mat.Data, int(size))
+
+	return binary.Read(buf, binary.LittleEndian, m.mat.Data)
+}
+
+// MarshalBinary encodes the receiver into a binary form and returns the result.
+//
+// Vector is little-endian encoded as follows:
+//   0 -  7  number of elements     (int64)
+//   8 - ..  vector's data elements (float64)
+func (v Vector) MarshalBinary() ([]byte, error) {
+	bufLen := int64(sizeInt64) + int64(v.n)*int64(sizeFloat64)
+	if bufLen <= 0 {
+		// bufLen is too big and has wrapped around.
+		return nil, errTooBig
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, bufLen))
+	err := binary.Write(buf, binary.LittleEndian, int64(v.n))
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < v.n; i++ {
+		err = binary.Write(buf, binary.LittleEndian, v.at(i))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalBinary decodes the binary form into the receiver.
+// It panics if the receiver is a non-zero Vector.
+//
+// See MarshalBinary for the on-disk layout.
+//
+// Limited checks on the validity of the binary input are performed:
+//  - matrix.ErrShape is returned if the number of rows is negative,
+//  - an error is returned if the resulting Vector is too
+//  big for the current architecture (e.g. a 16GB vector written by a
+//  64b application and read back from a 32b application.)
+// UnmarshalBinary does not limit the size of the unmarshaled vector, and so
+// it should not be used on untrusted data.
+func (v *Vector) UnmarshalBinary(data []byte) error {
+	if !v.isZero() {
+		panic("mat64: unmarshal into non-zero vector")
+	}
+
+	buf := bytes.NewReader(data)
+	var n int64
+	err := binary.Read(buf, binary.LittleEndian, &n)
+	if err != nil {
+		return err
+	}
+
+	if n < 0 {
+		return errBadSize
+	}
+	if n > maxLen {
+		return errTooBig
+	}
+	if len(data) != int(n)*sizeFloat64+sizeInt64 {
+		return errBadBuffer
+	}
+
+	v.n = int(n)
+	v.mat.Inc = 1
+	v.mat.Data = use(v.mat.Data, v.n)
+
+	return binary.Read(buf, binary.LittleEndian, v.mat.Data)
+}

--- a/mat64/io_test.go
+++ b/mat64/io_test.go
@@ -4,28 +4,134 @@
 
 package mat64
 
-import "testing"
+import (
+	"bytes"
+	"encoding"
+	"math"
+	"testing"
 
-func TestDenseRW(t *testing.T) {
-	for i, test := range []*Dense{
-		NewDense(0, 0, []float64{}),
-		NewDense(2, 2, []float64{1, 2, 3, 4}),
-		NewDense(2, 3, []float64{1, 2, 3, 4, 5, 6}),
-		NewDense(3, 2, []float64{1, 2, 3, 4, 5, 6}),
-		NewDense(3, 3, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}),
-		NewDense(3, 3, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}).View(0, 0, 2, 2).(*Dense),
-		NewDense(3, 3, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}).View(1, 1, 2, 2).(*Dense),
-		NewDense(3, 3, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}).View(0, 1, 3, 2).(*Dense),
-	} {
-		buf, err := test.MarshalBinary()
+	"github.com/gonum/blas/blas64"
+)
+
+var (
+	_ encoding.BinaryMarshaler   = (*Dense)(nil)
+	_ encoding.BinaryUnmarshaler = (*Dense)(nil)
+	_ encoding.BinaryMarshaler   = (*Vector)(nil)
+	_ encoding.BinaryUnmarshaler = (*Vector)(nil)
+)
+
+var denseData = []struct {
+	raw  []byte
+	want *Dense
+	eq   func(got, want Matrix) bool
+}{
+	{
+		raw:  []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"),
+		want: NewDense(0, 0, []float64{}),
+		eq:   Equal,
+	},
+	{
+		raw:  []byte("\x02\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\b@\x00\x00\x00\x00\x00\x00\x10@"),
+		want: NewDense(2, 2, []float64{1, 2, 3, 4}),
+		eq:   Equal,
+	},
+	{
+		raw:  []byte("\x02\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\b@\x00\x00\x00\x00\x00\x00\x10@\x00\x00\x00\x00\x00\x00\x14@\x00\x00\x00\x00\x00\x00\x18@"),
+		want: NewDense(2, 3, []float64{1, 2, 3, 4, 5, 6}),
+		eq:   Equal,
+	},
+	{
+		raw:  []byte("\x03\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\b@\x00\x00\x00\x00\x00\x00\x10@\x00\x00\x00\x00\x00\x00\x14@\x00\x00\x00\x00\x00\x00\x18@"),
+		want: NewDense(3, 2, []float64{1, 2, 3, 4, 5, 6}),
+		eq:   Equal,
+	},
+	{
+		raw:  []byte("\x03\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\b@\x00\x00\x00\x00\x00\x00\x10@\x00\x00\x00\x00\x00\x00\x14@\x00\x00\x00\x00\x00\x00\x18@\x00\x00\x00\x00\x00\x00\x1c@\x00\x00\x00\x00\x00\x00 @\x00\x00\x00\x00\x00\x00\"@"),
+		want: NewDense(3, 3, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}),
+		eq:   Equal,
+	},
+	{
+		raw:  []byte("\x02\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x10@\x00\x00\x00\x00\x00\x00\x14@"),
+		want: NewDense(3, 3, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}).View(0, 0, 2, 2).(*Dense),
+		eq:   Equal,
+	},
+	{
+		raw:  []byte("\x02\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14@\x00\x00\x00\x00\x00\x00\x18@\x00\x00\x00\x00\x00\x00 @\x00\x00\x00\x00\x00\x00\"@"),
+		want: NewDense(3, 3, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}).View(1, 1, 2, 2).(*Dense),
+		eq:   Equal,
+	},
+	{
+		raw:  []byte("\x03\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\b@\x00\x00\x00\x00\x00\x00\x14@\x00\x00\x00\x00\x00\x00\x18@\x00\x00\x00\x00\x00\x00 @\x00\x00\x00\x00\x00\x00\"@"),
+		want: NewDense(3, 3, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}).View(0, 1, 3, 2).(*Dense),
+		eq:   Equal,
+	},
+	{
+		raw:  []byte("\x01\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\xff\x00\x00\x00\x00\x00\x00\xf0\u007f\x01\x00\x00\x00\x00\x00\xf8\u007f"),
+		want: NewDense(1, 4, []float64{0, math.Inf(-1), math.Inf(+1), math.NaN()}),
+		eq: func(got, want Matrix) bool {
+			for _, v := range []bool{
+				got.At(0, 0) == 0,
+				math.IsInf(got.At(0, 1), -1),
+				math.IsInf(got.At(0, 2), +1),
+				math.IsNaN(got.At(0, 3)),
+			} {
+				if !v {
+					return false
+				}
+			}
+			return true
+		},
+	},
+}
+
+func TestDenseMarshal(t *testing.T) {
+	for i, test := range denseData {
+		buf, err := test.want.MarshalBinary()
 		if err != nil {
-			t.Errorf("error encoding test #%d: %v\n", i, err)
+			t.Errorf("error encoding test-%d: %v\n", i, err)
+			continue
 		}
 
-		nrows, ncols := test.Dims()
+		nrows, ncols := test.want.Dims()
 		sz := nrows*ncols*sizeFloat64 + 2*sizeInt64
 		if len(buf) != sz {
-			t.Errorf("encoded size test #%d: want=%d got=%d\n", i, sz, len(buf))
+			t.Errorf("encoded size test-%d: want=%d got=%d\n", i, sz, len(buf))
+		}
+
+		if !bytes.Equal(buf, test.raw) {
+			t.Errorf("error encoding test-%d: bytes mismatch.\n got=%q\nwant=%q\n",
+				i,
+				string(buf),
+				string(test.raw),
+			)
+			continue
+		}
+	}
+}
+
+func TestDenseUnmarshal(t *testing.T) {
+	for i, test := range denseData {
+		var v Dense
+		err := v.UnmarshalBinary(test.raw)
+		if err != nil {
+			t.Errorf("error decoding test-%d: %v\n", i, err)
+			continue
+		}
+		if !test.eq(&v, test.want) {
+			t.Errorf("error decoding test-%d: values differ.\n got=%v\nwant=%v\n",
+				i,
+				&v,
+				test.want,
+			)
+		}
+	}
+}
+
+func TestDenseIORoundTrip(t *testing.T) {
+	for i, test := range denseData {
+		buf, err := test.want.MarshalBinary()
+		if err != nil {
+			t.Errorf("error encoding test #%d: %v\n", i, err)
 		}
 
 		var got Dense
@@ -34,8 +140,139 @@ func TestDenseRW(t *testing.T) {
 			t.Errorf("error decoding test #%d: %v\n", i, err)
 		}
 
-		if !Equal(&got, test) {
-			t.Errorf("r/w test #%d failed\nwant=%#v\n got=%#v\n", i, test, &got)
+		if !test.eq(&got, test.want) {
+			t.Errorf("r/w test #%d failed\nwant=%#v\n got=%#v\n", i, test.want, &got)
+		}
+	}
+}
+
+var vectorData = []struct {
+	raw  []byte
+	want *Vector
+	eq   func(got, want Matrix) bool
+}{
+	{
+		raw:  []byte("\x00\x00\x00\x00\x00\x00\x00\x00"),
+		want: NewVector(0, []float64{}),
+		eq:   Equal,
+	},
+	{
+		raw:  []byte("\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\b@\x00\x00\x00\x00\x00\x00\x10@"),
+		want: NewVector(4, []float64{1, 2, 3, 4}),
+		eq:   Equal,
+	},
+	{
+		raw:  []byte("\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\b@\x00\x00\x00\x00\x00\x00\x10@\x00\x00\x00\x00\x00\x00\x14@\x00\x00\x00\x00\x00\x00\x18@"),
+		want: NewVector(6, []float64{1, 2, 3, 4, 5, 6}),
+		eq:   Equal,
+	},
+	{
+		raw:  []byte("\t\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\b@\x00\x00\x00\x00\x00\x00\x10@\x00\x00\x00\x00\x00\x00\x14@\x00\x00\x00\x00\x00\x00\x18@\x00\x00\x00\x00\x00\x00\x1c@\x00\x00\x00\x00\x00\x00 @\x00\x00\x00\x00\x00\x00\"@"),
+		want: NewVector(9, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}),
+		eq:   Equal,
+	},
+	{
+		raw:  []byte("\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\b@"),
+		want: NewVector(9, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}).ViewVec(0, 3),
+		eq:   Equal,
+	},
+	{
+		raw:  []byte("\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\b@\x00\x00\x00\x00\x00\x00\x10@"),
+		want: NewVector(9, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}).ViewVec(1, 3),
+		eq:   Equal,
+	},
+	{
+		raw:  []byte("\b\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\b@\x00\x00\x00\x00\x00\x00\x10@\x00\x00\x00\x00\x00\x00\x14@\x00\x00\x00\x00\x00\x00\x18@\x00\x00\x00\x00\x00\x00\x1c@\x00\x00\x00\x00\x00\x00 @"),
+		want: NewVector(9, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}).ViewVec(0, 8),
+		eq:   Equal,
+	},
+	{
+		raw: []byte("\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\b@\x00\x00\x00\x00\x00\x00\x18@"),
+		want: &Vector{
+			mat: blas64.Vector{
+				Data: []float64{0, 1, 2, 3, 4, 5, 6},
+				Inc:  3,
+			},
+			n: 3,
+		},
+		eq: Equal,
+	},
+	{
+		raw:  []byte("\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\xff\x00\x00\x00\x00\x00\x00\xf0\u007f\x01\x00\x00\x00\x00\x00\xf8\u007f"),
+		want: NewVector(4, []float64{0, math.Inf(-1), math.Inf(+1), math.NaN()}),
+		eq: func(got, want Matrix) bool {
+			for _, v := range []bool{
+				got.At(0, 0) == 0,
+				math.IsInf(got.At(1, 0), -1),
+				math.IsInf(got.At(2, 0), +1),
+				math.IsNaN(got.At(3, 0)),
+			} {
+				if !v {
+					return false
+				}
+			}
+			return true
+		},
+	},
+}
+
+func TestVectorMarshal(t *testing.T) {
+	for i, test := range vectorData {
+		buf, err := test.want.MarshalBinary()
+		if err != nil {
+			t.Errorf("error encoding test-%d: %v\n", i, err)
+			continue
+		}
+
+		nrows, ncols := test.want.Dims()
+		sz := nrows*ncols*sizeFloat64 + sizeInt64
+		if len(buf) != sz {
+			t.Errorf("encoded size test-%d: want=%d got=%d\n", i, sz, len(buf))
+		}
+
+		if !bytes.Equal(buf, test.raw) {
+			t.Errorf("error encoding test-%d: bytes mismatch.\n got=%q\nwant=%q\n",
+				i,
+				string(buf),
+				string(test.raw),
+			)
+			continue
+		}
+	}
+}
+
+func TestVectorUnmarshal(t *testing.T) {
+	for i, test := range vectorData {
+		var v Vector
+		err := v.UnmarshalBinary(test.raw)
+		if err != nil {
+			t.Errorf("error decoding test-%d: %v\n", i, err)
+			continue
+		}
+		if !test.eq(&v, test.want) {
+			t.Errorf("error decoding test-%d: values differ.\n got=%v\nwant=%v\n",
+				i,
+				&v,
+				test.want,
+			)
+		}
+	}
+}
+
+func TestVectorIORoundTrip(t *testing.T) {
+	for i, test := range vectorData {
+		buf, err := test.want.MarshalBinary()
+		if err != nil {
+			t.Errorf("error encoding test #%d: %v\n", i, err)
+		}
+
+		var got Vector
+		err = got.UnmarshalBinary(buf)
+		if err != nil {
+			t.Errorf("error decoding test #%d: %v\n", i, err)
+		}
+		if !test.eq(&got, test.want) {
+			t.Errorf("r/w test #%d failed\n got=%#v\nwant=%#v\n", i, &got, test.want)
 		}
 	}
 }


### PR DESCRIPTION
This CL makes *mat64.Vector implement encoding.BinaryMarshaler and
encoding.BinaryUnmarshaler.

Fixes gonum/matrix#337.