### PR TITLE
mat64: implement binary streamers

### DIFF
--- a/mat64/io.go
+++ b/mat64/io.go
@@ -7,6 +7,7 @@ package mat64
 import (
 	"encoding/binary"
 	"errors"
+	"io"
 	"math"
 )
 
@@ -60,6 +61,41 @@ func (m Dense) MarshalBinary() ([]byte, error) {
 	return buf, nil
 }
 
+// MarshalBinaryTo encodes the receiver into a binary form and writes it into w.
+// MarshalBinaryTo returns the number of bytes written into w and an error, if any.
+//
+// See MarshalBinary for the on-disk layout.
+func (m Dense) MarshalBinaryTo(w io.Writer) (int, error) {
+	var n int
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(m.mat.Rows))
+	nn, err := w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	binary.LittleEndian.PutUint64(buf[:], uint64(m.mat.Cols))
+	nn, err = w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+
+	r, c := m.Dims()
+	for i := 0; i < r; i++ {
+		for j := 0; j < c; j++ {
+			binary.LittleEndian.PutUint64(buf[:], math.Float64bits(m.at(i, j)))
+			nn, err = w.Write(buf[:])
+			n += nn
+			if err != nil {
+				return n, err
+			}
+		}
+	}
+
+	return n, nil
+}
+
 // UnmarshalBinary decodes the binary form into the receiver.
 // It panics if the receiver is a non-zero Dense matrix.
 //
@@ -99,19 +135,70 @@ func (m *Dense) UnmarshalBinary(data []byte) error {
 		return errBadBuffer
 	}
 
-	m.mat.Rows = int(rows)
-	m.mat.Cols = int(cols)
-	m.mat.Stride = int(cols)
-	m.capRows = int(rows)
-	m.capCols = int(cols)
-	m.mat.Data = use(m.mat.Data, int(size))
-
+	m.reuseAs(int(rows), int(cols))
 	for i := range m.mat.Data {
 		m.mat.Data[i] = math.Float64frombits(binary.LittleEndian.Uint64(data[p : p+sizeFloat64]))
 		p += sizeFloat64
 	}
 
 	return nil
+}
+
+// UnmarshalBinaryFrom decodes the binary form into the receiver and returns
+// the number of bytes read and an error if any.
+// It panics if the receiver is a non-zero Dense matrix.
+//
+// See MarshalBinary for the on-disk layout.
+//
+// Limited checks on the validity of the binary input are performed:
+//  - matrix.ErrShape is returned if the number of rows or columns is negative,
+//  - an error is returned if the resulting Dense matrix is too
+//  big for the current architecture (e.g. a 16GB matrix written by a
+//  64b application and read back from a 32b application.)
+// UnmarshalBinary does not limit the size of the unmarshaled matrix, and so
+// it should not be used on untrusted data.
+func (m *Dense) UnmarshalBinaryFrom(r io.Reader) (int, error) {
+	if !m.isZero() {
+		panic("mat64: unmarshal into non-zero matrix")
+	}
+
+	var (
+		n   int
+		buf [8]byte
+	)
+	nn, err := readFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	rows := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	nn, err = readFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	cols := int64(binary.LittleEndian.Uint64(buf[:]))
+	if rows < 0 || cols < 0 {
+		return n, errBadSize
+	}
+
+	size := rows * cols
+	if int(size) < 0 || size > maxLen {
+		return n, errTooBig
+	}
+
+	m.reuseAs(int(rows), int(cols))
+	for i := range m.mat.Data {
+		nn, err = readFull(r, buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		m.mat.Data[i] = math.Float64frombits(binary.LittleEndian.Uint64(buf[:]))
+	}
+
+	return n, nil
 }
 
 // MarshalBinary encodes the receiver into a binary form and returns the result.
@@ -137,6 +224,35 @@ func (v Vector) MarshalBinary() ([]byte, error) {
 	}
 
 	return buf, nil
+}
+
+// MarshalBinaryTo encodes the receiver into a binary form, writes it to w and
+// returns the number of bytes written and an error if any.
+//
+// See MarshalBainry for the on-disk format.
+func (v Vector) MarshalBinaryTo(w io.Writer) (int, error) {
+	var (
+		n   int
+		buf [8]byte
+	)
+
+	binary.LittleEndian.PutUint64(buf[:], uint64(v.n))
+	nn, err := w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+
+	for i := 0; i < v.n; i++ {
+		binary.LittleEndian.PutUint64(buf[:], math.Float64bits(v.at(i)))
+		nn, err = w.Write(buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+	}
+
+	return n, nil
 }
 
 // UnmarshalBinary decodes the binary form into the receiver.
@@ -169,13 +285,76 @@ func (v *Vector) UnmarshalBinary(data []byte) error {
 		return errBadBuffer
 	}
 
-	v.n = int(n)
-	v.mat.Inc = 1
-	v.mat.Data = use(v.mat.Data, v.n)
+	v.reuseAs(int(n))
 	for i := range v.mat.Data {
 		v.mat.Data[i] = math.Float64frombits(binary.LittleEndian.Uint64(data[p : p+sizeFloat64]))
 		p += sizeFloat64
 	}
 
 	return nil
+}
+
+// UnmarshalBinaryFrom decodes the binary form into the receiver, from the
+// io.Reader and returns the number of bytes read and an error if any.
+// It panics if the receiver is a non-zero Vector.
+//
+// See MarshalBinary for the on-disk layout.
+// See UnmarshalBinary for the list of sanity checks performed on the input.
+func (v *Vector) UnmarshalBinaryFrom(r io.Reader) (int, error) {
+	if !v.isZero() {
+		panic("mat64: unmarshal into non-zero vector")
+	}
+
+	var (
+		n   int
+		buf [8]byte
+	)
+	nn, err := readFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	sz := int64(binary.LittleEndian.Uint64(buf[:]))
+	if sz < 0 {
+		return n, errBadSize
+	}
+	if sz > maxLen {
+		return n, errTooBig
+	}
+
+	v.reuseAs(int(sz))
+	for i := range v.mat.Data {
+		nn, err = readFull(r, buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		v.mat.Data[i] = math.Float64frombits(binary.LittleEndian.Uint64(buf[:]))
+	}
+
+	if n != sizeInt64+int(sz)*sizeFloat64 {
+		return n, io.ErrUnexpectedEOF
+	}
+
+	return n, nil
+}
+
+// readFull reads from r into buf until it has read len(buf).
+// It returns the number of bytes copied and an error if fewer bytes were read.
+// If an EOF happens after reading fewer than len(buf) bytes, io.ErrUnexpectedEOF is returned.
+func readFull(r io.Reader, buf []byte) (int, error) {
+	var n int
+	var err error
+	for n < len(buf) && err == nil {
+		var nn int
+		nn, err = r.Read(buf[n:])
+		n += nn
+	}
+	if n == len(buf) {
+		return n, nil
+	}
+	if err == io.EOF {
+		return n, io.ErrUnexpectedEOF
+	}
+	return n, err
 }


### PR DESCRIPTION
Introduce:
- MarshalBinaryTo(w io.Writer) (int, error) and
- UnmarshalBinaryFrom(r io.Reader) (int, error)

for Dense and Vector.
Re-wire MarshalBinary and UnmarshalBinary to use the above, with slight
modifications.

Fixes #344.