### PR TITLE
mat64: add support for TriDense shadowing detection

### DIFF
--- a/gendoc.go
+++ b/gendoc.go
@@ -265,8 +265,6 @@ package {{.Name}}
 {{template "switching" .}}
 {{template "invariants" .}}
 {{template "aliasing" .}}
-// BUG(kortschak) Currently only RawMatrixer and Vector aliasing detection is supported.
-//
 package {{.Name}}
 `,
 	},

--- a/mat64/doc.go
+++ b/mat64/doc.go
@@ -155,6 +155,4 @@
 // conversion has occurred through a mat64 API function. Method behavior is undefined
 // if there is undetected overlap.
 //
-// BUG(kortschak) Currently only RawMatrixer and Vector aliasing detection is supported.
-//
 package mat64

--- a/mat64/triangular.go
+++ b/mat64/triangular.go
@@ -292,6 +292,9 @@ func (t *TriDense) Copy(a Matrix) (r, c int) {
 // Note that matrix inversion is numerically unstable, and should generally be
 // avoided where possible, for example by using the Solve routines.
 func (t *TriDense) InverseTri(a Triangular) error {
+	if rt, ok := a.(RawTriangular); ok {
+		t.checkOverlap(rt.RawTriangular())
+	}
 	n, _ := a.Triangle()
 	t.reuseAs(a.Triangle())
 	t.Copy(a)


### PR DESCRIPTION
This only happens in one place. It seems to me that it would make more sense for the check to be done in TriDense.Copy, but we're not doing that for reasons that I don't recall (possibly because copy doesn't panic?).

@btracey @vladimir-ch Please take a look.