### PR TITLE
mat64: add r/w benchmarks for Dense and Vector

### DIFF
--- a/mat64/io_test.go
+++ b/mat64/io_test.go
@@ -276,3 +276,83 @@ func TestVectorIORoundTrip(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkMarshalDense10(b *testing.B)    { marshalBinaryBenchDense(b, 10) }
+func BenchmarkMarshalDense100(b *testing.B)   { marshalBinaryBenchDense(b, 100) }
+func BenchmarkMarshalDense1000(b *testing.B)  { marshalBinaryBenchDense(b, 1000) }
+func BenchmarkMarshalDense10000(b *testing.B) { marshalBinaryBenchDense(b, 10000) }
+
+func marshalBinaryBenchDense(b *testing.B, size int) {
+	data := make([]float64, size)
+	for i := range data {
+		data[i] = float64(i)
+	}
+	m := NewDense(1, size, data)
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		m.MarshalBinary()
+	}
+}
+
+func BenchmarkUnmarshalDense10(b *testing.B)    { unmarshalBinaryBenchDense(b, 10) }
+func BenchmarkUnmarshalDense100(b *testing.B)   { unmarshalBinaryBenchDense(b, 100) }
+func BenchmarkUnmarshalDense1000(b *testing.B)  { unmarshalBinaryBenchDense(b, 1000) }
+func BenchmarkUnmarshalDense10000(b *testing.B) { unmarshalBinaryBenchDense(b, 10000) }
+
+func unmarshalBinaryBenchDense(b *testing.B, size int) {
+	data := make([]float64, size)
+	for i := range data {
+		data[i] = float64(i)
+	}
+	buf, err := NewDense(1, size, data).MarshalBinary()
+	if err != nil {
+		b.Fatalf("error creating binary buffer (size=%d): %v\n", size, err)
+	}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		var m Dense
+		m.UnmarshalBinary(buf)
+	}
+}
+
+func BenchmarkMarshalVector10(b *testing.B)    { marshalBinaryBenchVector(b, 10) }
+func BenchmarkMarshalVector100(b *testing.B)   { marshalBinaryBenchVector(b, 100) }
+func BenchmarkMarshalVector1000(b *testing.B)  { marshalBinaryBenchVector(b, 1000) }
+func BenchmarkMarshalVector10000(b *testing.B) { marshalBinaryBenchVector(b, 10000) }
+
+func marshalBinaryBenchVector(b *testing.B, size int) {
+	data := make([]float64, size)
+	for i := range data {
+		data[i] = float64(i)
+	}
+	vec := NewVector(size, data)
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		vec.MarshalBinary()
+	}
+}
+
+func BenchmarkUnmarshalVector10(b *testing.B)    { unmarshalBinaryBenchVector(b, 10) }
+func BenchmarkUnmarshalVector100(b *testing.B)   { unmarshalBinaryBenchVector(b, 100) }
+func BenchmarkUnmarshalVector1000(b *testing.B)  { unmarshalBinaryBenchVector(b, 1000) }
+func BenchmarkUnmarshalVector10000(b *testing.B) { unmarshalBinaryBenchVector(b, 10000) }
+
+func unmarshalBinaryBenchVector(b *testing.B, size int) {
+	data := make([]float64, size)
+	for i := range data {
+		data[i] = float64(i)
+	}
+	buf, err := NewVector(size, data).MarshalBinary()
+	if err != nil {
+		b.Fatalf("error creating binary buffer (size=%d): %v\n", size, err)
+	}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		var vec Vector
+		vec.UnmarshalBinary(buf)
+	}
+}


### PR DESCRIPTION
```
BenchmarkMarshalDense10-4      	  500000	      2635 ns/op	     400 B/op	      26 allocs/op
BenchmarkMarshalDense100-4     	  100000	     22186 ns/op	    2640 B/op	     206 allocs/op
BenchmarkMarshalDense1000-4    	   10000	    218528 ns/op	   24336 B/op	    2006 allocs/op
BenchmarkMarshalDense10000-4   	    1000	   2173997 ns/op	  242068 B/op	   20006 allocs/op
BenchmarkUnmarshalDense10-4    	 2000000	       914 ns/op	     272 B/op	       8 allocs/op
BenchmarkUnmarshalDense100-4   	  500000	      3808 ns/op	    1904 B/op	       8 allocs/op
BenchmarkUnmarshalDense1000-4  	   50000	     32730 ns/op	   16496 B/op	       8 allocs/op
BenchmarkUnmarshalDense10000-4 	    5000	    310645 ns/op	  163955 B/op	       8 allocs/op
BenchmarkMarshalVector10-4     	 1000000	      2467 ns/op	     384 B/op	      24 allocs/op
BenchmarkMarshalVector100-4    	  100000	     21861 ns/op	    2624 B/op	     204 allocs/op
BenchmarkMarshalVector1000-4   	   10000	    214783 ns/op	   24320 B/op	    2004 allocs/op
BenchmarkMarshalVector10000-4  	    1000	   2155109 ns/op	  242052 B/op	   20004 allocs/op
BenchmarkUnmarshalVector10-4   	 2000000	       813 ns/op	     256 B/op	       6 allocs/op
BenchmarkUnmarshalVector100-4  	  500000	      3701 ns/op	    1888 B/op	       6 allocs/op
BenchmarkUnmarshalVector1000-4 	   50000	     32248 ns/op	   16480 B/op	       6 allocs/op
BenchmarkUnmarshalVector10000-4	    5000	    311020 ns/op	  163939 B/op	       6 allocs/op
```
Updates #346