### PR TITLE
mat64: optimize r/w of Dense and Vector

### DIFF
--- a/mat64/io.go
+++ b/mat64/io.go
@@ -5,9 +5,9 @@
 package mat64
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
+	"math"
 )
 
 const (
@@ -20,6 +20,7 @@ var (
 	sizeFloat64 = binary.Size(float64(0))
 
 	errTooBig    = errors.New("mat64: resulting data slice too big")
+	errTooSmall  = errors.New("mat64: input slice too small")
 	errBadBuffer = errors.New("mat64: data buffer size mismatch")
 	errBadSize   = errors.New("mat64: invalid dimension")
 )
@@ -41,27 +42,22 @@ func (m Dense) MarshalBinary() ([]byte, error) {
 		return nil, errTooBig
 	}
 
-	buf := bytes.NewBuffer(make([]byte, 0, bufLen))
-	err := binary.Write(buf, binary.LittleEndian, int64(m.mat.Rows))
-	if err != nil {
-		return nil, err
-	}
-	err = binary.Write(buf, binary.LittleEndian, int64(m.mat.Cols))
-	if err != nil {
-		return nil, err
-	}
+	p := 0
+	buf := make([]byte, bufLen)
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(m.mat.Rows))
+	p += sizeInt64
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(m.mat.Cols))
+	p += sizeInt64
 
 	r, c := m.Dims()
 	for i := 0; i < r; i++ {
 		for j := 0; j < c; j++ {
-			err = binary.Write(buf, binary.LittleEndian, m.at(i, j))
-			if err != nil {
-				return nil, err
-			}
+			binary.LittleEndian.PutUint64(buf[p:p+sizeFloat64], math.Float64bits(m.at(i, j)))
+			p += sizeFloat64
 		}
 	}
 
-	return buf.Bytes(), nil
+	return buf, nil
 }
 
 // UnmarshalBinary decodes the binary form into the receiver.
@@ -81,18 +77,15 @@ func (m *Dense) UnmarshalBinary(data []byte) error {
 		panic("mat64: unmarshal into non-zero matrix")
 	}
 
-	buf := bytes.NewReader(data)
-	var rows int64
-	err := binary.Read(buf, binary.LittleEndian, &rows)
-	if err != nil {
-		return err
-	}
-	var cols int64
-	err = binary.Read(buf, binary.LittleEndian, &cols)
-	if err != nil {
-		return err
+	if len(data) < 2*sizeInt64 {
+		return errTooSmall
 	}
 
+	p := 0
+	rows := int64(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+	cols := int64(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
 	if rows < 0 || cols < 0 {
 		return errBadSize
 	}
@@ -113,7 +106,12 @@ func (m *Dense) UnmarshalBinary(data []byte) error {
 	m.capCols = int(cols)
 	m.mat.Data = use(m.mat.Data, int(size))
 
-	return binary.Read(buf, binary.LittleEndian, m.mat.Data)
+	for i := range m.mat.Data {
+		m.mat.Data[i] = math.Float64frombits(binary.LittleEndian.Uint64(data[p : p+sizeFloat64]))
+		p += sizeFloat64
+	}
+
+	return nil
 }
 
 // MarshalBinary encodes the receiver into a binary form and returns the result.
@@ -128,20 +126,17 @@ func (v Vector) MarshalBinary() ([]byte, error) {
 		return nil, errTooBig
 	}
 
-	buf := bytes.NewBuffer(make([]byte, 0, bufLen))
-	err := binary.Write(buf, binary.LittleEndian, int64(v.n))
-	if err != nil {
-		return nil, err
-	}
+	p := 0
+	buf := make([]byte, bufLen)
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(v.n))
+	p += sizeInt64
 
 	for i := 0; i < v.n; i++ {
-		err = binary.Write(buf, binary.LittleEndian, v.at(i))
-		if err != nil {
-			return nil, err
-		}
+		binary.LittleEndian.PutUint64(buf[p:p+sizeFloat64], math.Float64bits(v.at(i)))
+		p += sizeFloat64
 	}
 
-	return buf.Bytes(), nil
+	return buf, nil
 }
 
 // UnmarshalBinary decodes the binary form into the receiver.
@@ -161,13 +156,9 @@ func (v *Vector) UnmarshalBinary(data []byte) error {
 		panic("mat64: unmarshal into non-zero vector")
 	}
 
-	buf := bytes.NewReader(data)
-	var n int64
-	err := binary.Read(buf, binary.LittleEndian, &n)
-	if err != nil {
-		return err
-	}
-
+	p := 0
+	n := int64(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
 	if n < 0 {
 		return errBadSize
 	}
@@ -181,6 +172,10 @@ func (v *Vector) UnmarshalBinary(data []byte) error {
 	v.n = int(n)
 	v.mat.Inc = 1
 	v.mat.Data = use(v.mat.Data, v.n)
+	for i := range v.mat.Data {
+		v.mat.Data[i] = math.Float64frombits(binary.LittleEndian.Uint64(data[p : p+sizeFloat64]))
+		p += sizeFloat64
+	}
 
-	return binary.Read(buf, binary.LittleEndian, v.mat.Data)
+	return nil
 }


### PR DESCRIPTION
Fixes #346
```
name                    old time/op    new time/op    delta
MarshalDense10-4          2.66µs ± 1%    0.42µs ± 1%  -84.09%  (p=0.000 n=4+10)
MarshalDense100-4         22.3µs ± 1%     2.4µs ± 0%  -89.17%  (p=0.001 n=4+11)
MarshalDense1000-4         218µs ± 1%      23µs ± 1%  -89.54%  (p=0.001 n=4+11)
MarshalDense10000-4       2.18ms ± 1%    0.22ms ± 1%  -89.77%  (p=0.001 n=4+11)
UnmarshalDense10-4         918ns ± 0%     258ns ± 0%  -71.88%  (p=0.000 n=4+11)
UnmarshalDense100-4       3.83µs ± 0%    1.73µs ± 1%  -54.83%  (p=0.001 n=4+11)
UnmarshalDense1000-4      33.0µs ± 2%    16.0µs ± 1%  -51.33%  (p=0.001 n=4+11)
UnmarshalDense10000-4      309µs ± 0%     159µs ± 1%  -48.41%  (p=0.001 n=4+11)
MarshalVector10-4         2.48µs ± 1%    0.41µs ± 1%  -83.42%  (p=0.000 n=4+11)
MarshalVector100-4        21.9µs ± 1%     2.6µs ± 1%  -88.02%  (p=0.001 n=4+11)
MarshalVector1000-4        216µs ± 1%      24µs ± 1%  -88.66%  (p=0.001 n=4+11)
MarshalVector10000-4      2.15ms ± 1%    0.24ms ± 1%  -88.93%  (p=0.001 n=4+11)
UnmarshalVector10-4        811ns ± 0%     242ns ± 1%  -70.13%   (p=0.000 n=4+9)
UnmarshalVector100-4      3.75µs ± 0%    1.70µs ± 1%  -54.60%  (p=0.000 n=4+11)
UnmarshalVector1000-4     32.8µs ± 1%    16.0µs ± 1%  -51.17%  (p=0.001 n=4+11)
UnmarshalVector10000-4     309µs ± 1%     160µs ± 1%  -48.11%  (p=0.001 n=4+11)

name                    old alloc/op   new alloc/op   delta
MarshalDense10-4            400B ± 0%      208B ± 0%  -48.00%  (p=0.000 n=4+11)
MarshalDense100-4         2.64kB ± 0%    1.01kB ± 0%  -61.82%  (p=0.000 n=4+11)
MarshalDense1000-4        24.3kB ± 0%     8.3kB ± 0%  -65.88%  (p=0.000 n=4+11)
MarshalDense10000-4        242kB ± 0%      82kB ± 0%  -66.11%  (p=0.000 n=4+11)
UnmarshalDense10-4          272B ± 0%       80B ± 0%  -70.59%  (p=0.000 n=4+11)
UnmarshalDense100-4       1.90kB ± 0%    0.90kB ± 0%  -52.94%  (p=0.000 n=4+11)
UnmarshalDense1000-4      16.5kB ± 0%     8.2kB ± 0%  -50.34%  (p=0.000 n=4+11)
UnmarshalDense10000-4      164kB ± 0%      82kB ± 0%  -50.03%  (p=0.000 n=4+11)
MarshalVector10-4           384B ± 0%      208B ± 0%  -45.83%  (p=0.000 n=4+11)
MarshalVector100-4        2.62kB ± 0%    1.01kB ± 0%  -61.59%  (p=0.000 n=4+11)
MarshalVector1000-4       24.3kB ± 0%     8.3kB ± 0%  -65.86%  (p=0.000 n=4+11)
MarshalVector10000-4       242kB ± 0%      82kB ± 0%  -66.11%  (p=0.000 n=4+11)
UnmarshalVector10-4         256B ± 0%       80B ± 0%  -68.75%  (p=0.000 n=4+11)
UnmarshalVector100-4      1.89kB ± 0%    0.90kB ± 0%  -52.54%  (p=0.000 n=4+11)
UnmarshalVector1000-4     16.5kB ± 0%     8.2kB ± 0%  -50.29%  (p=0.000 n=4+11)
UnmarshalVector10000-4     164kB ± 0%      82kB ± 0%  -50.03%  (p=0.000 n=4+11)

name                    old allocs/op  new allocs/op  delta
MarshalDense10-4            26.0 ± 0%       2.0 ± 0%  -92.31%  (p=0.000 n=4+11)
MarshalDense100-4            206 ± 0%         2 ± 0%  -99.03%  (p=0.000 n=4+11)
MarshalDense1000-4         2.01k ± 0%     0.00k ± 0%  -99.90%  (p=0.000 n=4+11)
MarshalDense10000-4        20.0k ± 0%      0.0k ± 0%  -99.99%  (p=0.000 n=4+11)
UnmarshalDense10-4          8.00 ± 0%      1.00 ± 0%  -87.50%  (p=0.000 n=4+11)
UnmarshalDense100-4         8.00 ± 0%      1.00 ± 0%  -87.50%  (p=0.000 n=4+11)
UnmarshalDense1000-4        8.00 ± 0%      1.00 ± 0%  -87.50%  (p=0.000 n=4+11)
UnmarshalDense10000-4       8.00 ± 0%      1.00 ± 0%  -87.50%  (p=0.000 n=4+11)
MarshalVector10-4           24.0 ± 0%       2.0 ± 0%  -91.67%  (p=0.000 n=4+11)
MarshalVector100-4           204 ± 0%         2 ± 0%  -99.02%  (p=0.000 n=4+11)
MarshalVector1000-4        2.00k ± 0%     0.00k ± 0%  -99.90%  (p=0.000 n=4+11)
MarshalVector10000-4       20.0k ± 0%      0.0k ± 0%  -99.99%  (p=0.000 n=4+11)
UnmarshalVector10-4         6.00 ± 0%      1.00 ± 0%  -83.33%  (p=0.000 n=4+11)
UnmarshalVector100-4        6.00 ± 0%      1.00 ± 0%  -83.33%  (p=0.000 n=4+11)
UnmarshalVector1000-4       6.00 ± 0%      1.00 ± 0%  -83.33%  (p=0.000 n=4+11)
UnmarshalVector10000-4      6.00 ± 0%      1.00 ± 0%  -83.33%  (p=0.000 n=4+11)
```