### PR TITLE
mat64: tighten definition of Dot

### DIFF
--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -338,53 +338,15 @@ func Det(a Matrix) float64 {
 	return math.Exp(det) * sign
 }
 
-// Dot returns the sum of the element-wise products of the elements of a and b.
+// Dot returns the sum of the element-wise product of a and b.
 // Dot panics if the matrix sizes are unequal.
-func Dot(a, b Matrix) float64 {
-	r, c := a.Dims()
-	rb, cb := b.Dims()
-	if r != rb || c != cb {
+func Dot(a, b *Vector) float64 {
+	la := a.Len()
+	lb := b.Len()
+	if la != lb {
 		panic(matrix.ErrShape)
 	}
-	aU, aTrans := untranspose(a)
-	bU, bTrans := untranspose(b)
-	if rma, ok := aU.(RawVectorer); ok {
-		if rmb, ok := bU.(RawVectorer); ok {
-			if c > r {
-				r = c
-			}
-			return blas64.Dot(r, rma.RawVector(), rmb.RawVector())
-		}
-	}
-	var sum float64
-	if rma, ok := aU.(RawMatrixer); ok {
-		if rmb, ok := bU.(RawMatrixer); ok {
-			ra := rma.RawMatrix()
-			rb := rmb.RawMatrix()
-			if aTrans == bTrans {
-				for i := 0; i < ra.Rows; i++ {
-					sum += blas64.Dot(ra.Cols,
-						blas64.Vector{Inc: 1, Data: ra.Data[i*ra.Stride:]},
-						blas64.Vector{Inc: 1, Data: rb.Data[i*rb.Stride:]},
-					)
-				}
-				return sum
-			}
-			for i := 0; i < ra.Rows; i++ {
-				sum += blas64.Dot(ra.Cols,
-					blas64.Vector{Inc: 1, Data: ra.Data[i*ra.Stride:]},
-					blas64.Vector{Inc: rb.Stride, Data: rb.Data[i:]},
-				)
-			}
-			return sum
-		}
-	}
-	for i := 0; i < r; i++ {
-		for j := 0; j < c; j++ {
-			sum += a.At(i, j) * b.At(i, j)
-		}
-	}
-	return sum
+	return blas64.Dot(la, a.mat, b.mat)
 }
 
 // Equal returns whether the matrices a and b have the same size

--- a/mat64/matrix_test.go
+++ b/mat64/matrix_test.go
@@ -360,12 +360,23 @@ func TestDet(t *testing.T) {
 
 func TestDot(t *testing.T) {
 	f := func(a, b Matrix) interface{} {
-		return Dot(a, b)
+		return Dot(a.(*Vector), b.(*Vector))
 	}
 	denseComparison := func(a, b *Dense) interface{} {
-		return Dot(a, b)
+		ra, ca := a.Dims()
+		rb, cb := b.Dims()
+		if ra != rb || ca != cb {
+			panic(matrix.ErrShape)
+		}
+		var sum float64
+		for i := 0; i < ra; i++ {
+			for j := 0; j < ca; j++ {
+				sum += a.At(i, j) * b.At(i, j)
+			}
+		}
+		return sum
 	}
-	testTwoInputFunc(t, "Dot", f, denseComparison, sameAnswerFloatApprox, legalTypesAll, legalSizeSameRectangular)
+	testTwoInputFunc(t, "Dot", f, denseComparison, sameAnswerFloatApprox, legalTypesVecVec, legalSizeSameVec)
 }
 
 func TestEqual(t *testing.T) {


### PR DESCRIPTION
@btracey Please take a look.

@sjwhitworth This will break github.com/sjwhitworth/golearn/metrics/pairwise, but the breakage is fixed by using mat64.Norm [here](https://github.com/sjwhitworth/golearn/blob/master/metrics/pairwise/poly_kernel.go#L32) and [here](https://github.com/sjwhitworth/golearn/blob/master/metrics/pairwise/euclidean.go#L27). (You'll also get a performance improvement by using *mat64.Vector rather than *mat64.Dense if that will work for you.)