### PR TITLE
mat64: add Reset method to SymDense

### DIFF
--- a/mat64/dense.go
+++ b/mat64/dense.go
@@ -136,6 +136,17 @@ func (m *Dense) isolatedWorkspace(a Matrix) (w *Dense, restore func()) {
 	}
 }
 
+// Reset zeros the dimensions of the matrix so that it can be reused as the
+// receiver of a dimensionally restricted operation.
+//
+// See the Reseter interface for more information.
+func (m *Dense) Reset() {
+	// Row, Cols and Stride must be zeroed in unison.
+	m.mat.Rows, m.mat.Cols, m.mat.Stride = 0, 0, 0
+	m.capRows, m.capCols = 0, 0
+	m.mat.Data = m.mat.Data[:0]
+}
+
 func (m *Dense) isZero() bool {
 	// It must be the case that m.Dims() returns
 	// zeros in this case. See comment in Reset().
@@ -343,18 +354,6 @@ func (m *Dense) Grow(r, c int) Matrix {
 	t.capRows = r
 	t.capCols = c
 	return &t
-}
-
-// Reset zeros the dimensions of the matrix so that it can be reused as the
-// receiver of a dimensionally restricted operation.
-//
-// See the Reseter interface for more information.
-func (m *Dense) Reset() {
-	// No change of Stride, Rows and Cols to 0
-	// may be made unless all are set to 0.
-	m.mat.Rows, m.mat.Cols, m.mat.Stride = 0, 0, 0
-	m.capRows, m.capCols = 0, 0
-	m.mat.Data = m.mat.Data[:0]
 }
 
 // Clone makes a copy of a into the receiver, overwriting the previous value of

--- a/mat64/symmetric.go
+++ b/mat64/symmetric.go
@@ -105,7 +105,20 @@ func (s *SymDense) SetRawSymmetric(b blas64.Symmetric) {
 	s.mat = b
 }
 
+// Reset zeros the dimensions of the matrix so that it can be reused as the
+// receiver of a dimensionally restricted operation.
+//
+// See the Reseter interface for more information.
+func (s *SymDense) Reset() {
+	// No change of Stride and N to 0
+	// may be made unless both are set to 0.
+	s.mat.N, s.mat.Stride = 0, 0
+	s.mat.Data = s.mat.Data[:0]
+}
+
 func (s *SymDense) isZero() bool {
+	// It must be the case that m.Dims() returns
+	// zeros in this case. See comment in Reset().
 	return s.mat.N == 0
 }
 

--- a/mat64/symmetric.go
+++ b/mat64/symmetric.go
@@ -110,8 +110,7 @@ func (s *SymDense) SetRawSymmetric(b blas64.Symmetric) {
 //
 // See the Reseter interface for more information.
 func (s *SymDense) Reset() {
-	// No change of Stride and N to 0
-	// may be made unless both are set to 0.
+	// N and Stride must be zeroed in unison.
 	s.mat.N, s.mat.Stride = 0, 0
 	s.mat.Data = s.mat.Data[:0]
 }

--- a/mat64/triangular.go
+++ b/mat64/triangular.go
@@ -178,6 +178,19 @@ func (t *TriDense) RawTriangular() blas64.Triangular {
 	return t.mat
 }
 
+// Reset zeros the dimensions of the matrix so that it can be reused as the
+// receiver of a dimensionally restricted operation.
+//
+// See the Reseter interface for more information.
+func (t *TriDense) Reset() {
+	// N and Stride must be zeroed in unison.
+	t.mat.N, t.mat.Stride = 0, 0
+	// Defensively zero Uplo to ensure
+	// it is set correctly later.
+	t.mat.Uplo = 0
+	t.mat.Data = t.mat.Data[:0]
+}
+
 func (t *TriDense) isZero() bool {
 	// It must be the case that t.Dims() returns
 	// zeros in this case. See comment in Reset().
@@ -209,20 +222,6 @@ func (t *TriDense) reuseAs(n int, kind matrix.TriKind) {
 	if t.mat.N != n || t.mat.Uplo != ul {
 		panic(matrix.ErrShape)
 	}
-}
-
-// Reset zeros the dimensions of the matrix so that it can be reused as the
-// receiver of a dimensionally restricted operation.
-//
-// See the Reseter interface for more information.
-func (t *TriDense) Reset() {
-	// No change of Stride, N to 0 may
-	// be made unless both are set to 0.
-	t.mat.N, t.mat.Stride = 0, 0
-	// Defensively zero Uplo to ensure
-	// it is set correctly later.
-	t.mat.Uplo = 0
-	t.mat.Data = t.mat.Data[:0]
 }
 
 // Copy makes a copy of elements of a into the receiver. It is similar to the


### PR DESCRIPTION
This is needed for an allocation improvement to stat.CovarianceMatrix and stat.CorrelationMatrix.