### PR TITLE
mat64: extend TestInverse

### DIFF
--- a/mat64/dense_arithmetic.go
+++ b/mat64/dense_arithmetic.go
@@ -228,15 +228,7 @@ func (m *Dense) Inverse(a Matrix) error {
 			m.Copy(a)
 		}
 	default:
-		if m != aU {
-			m.Copy(a)
-		} else if aTrans {
-			// m and a share data so Copy cannot be used directly.
-			tmp := getWorkspace(r, c, false)
-			tmp.Copy(a)
-			m.Copy(tmp)
-			putWorkspace(tmp)
-		}
+		m.Copy(a)
 	}
 	ipiv := make([]int, r)
 	lapack64.Getrf(m.mat, ipiv)


### PR DESCRIPTION
@vladimir-ch @btracey Please take a look for discussion.

The single failing case is one where I have ignored the shadowing restrictions, so we do not guarantee that it will work. I am not entirely sure how I want to handle this. I think that probably leaving the test case in as a comment explaining why it would fail is the correct answer. What are your views?

Fixes #412.