### PR TITLE
mat64: reduce allocations when SVD is reused

### DIFF
--- a/mat64/svd.go
+++ b/mat64/svd.go
@@ -57,13 +57,13 @@ func (svd *SVD) Factorize(a Matrix, kind matrix.SVDKind) (ok bool) {
 			Rows:   m,
 			Cols:   m,
 			Stride: m,
-			Data:   make([]float64, m*m),
+			Data:   use(svd.u.Data, m*m),
 		}
 		svd.vt = blas64.General{
 			Rows:   n,
 			Cols:   n,
 			Stride: n,
-			Data:   make([]float64, n*n),
+			Data:   use(svd.vt.Data, n*n),
 		}
 		jobU = lapack.SVDAll
 		jobVT = lapack.SVDAll
@@ -75,13 +75,13 @@ func (svd *SVD) Factorize(a Matrix, kind matrix.SVDKind) (ok bool) {
 			Rows:   m,
 			Cols:   min(m, n),
 			Stride: min(m, n),
-			Data:   make([]float64, m*min(m, n)),
+			Data:   use(svd.u.Data, m*min(m, n)),
 		}
 		svd.vt = blas64.General{
 			Rows:   min(m, n),
 			Cols:   n,
 			Stride: n,
-			Data:   make([]float64, min(m, n)*n),
+			Data:   use(svd.vt.Data, min(m, n)*n),
 		}
 		jobU = lapack.SVDInPlace
 		jobVT = lapack.SVDInPlace
@@ -90,7 +90,7 @@ func (svd *SVD) Factorize(a Matrix, kind matrix.SVDKind) (ok bool) {
 	// A is destroyed on call, so copy the matrix.
 	aCopy := DenseCopyOf(a)
 	svd.kind = kind
-	svd.s = make([]float64, min(m, n))
+	svd.s = use(svd.s, min(m, n))
 
 	work := make([]float64, 1)
 	lapack64.Gesvd(jobU, jobVT, aCopy.mat, svd.u, svd.vt, svd.s, work, -1)


### PR DESCRIPTION
This comes out of discussion in the CCA PR in stat https://github.com/gonum/stat/pull/123#issuecomment-267486046. This change makes it more valuable to allow the CC to be reused. So that should probably happen - the SVD values need to be retained, so the internals need a bit of rework there when that happens.

I am trusting that the u, vt and s do not need to be zeroed - there is no indication in the docs that they do, and the tests reuse the SVD value, so I think this is OK, but @btracey please reassure me.

@btracey @vladimir-ch Please take a look.