### PR TITLE
Add `Exp` to TriDense

### DIFF
--- a/mat64/triangular.go
+++ b/mat64/triangular.go
@@ -402,6 +402,14 @@ func (t *TriDense) MulTri(a, b Triangular) {
 func (t *TriDense) Exp(a Triangular) {
 	n, kind := a.Triangle()
 	t.reuseAs(a.Triangle())
+
+	aU, _ := untransposeTri(a)
+	t.reuseAs(n, kind)
+	var restore func()
+	if t == aU {
+		t, restore = t.isolatedWorkspace(aU)
+		defer restore()
+	}
 	t.Copy(a)
 
 	if n&(n-1) == 0 {

--- a/mat64/triangular_test.go
+++ b/mat64/triangular_test.go
@@ -315,3 +315,48 @@ func TestTriMul(t *testing.T) {
 	receiver = NewTriDense(3, matrix.Upper, nil)
 	testTwoInput(t, "TriMul", receiver, method, denseComparison, legalTypesUpper, legalSizeTriMul, 1e-14)
 }
+
+func TestTriExp(t *testing.T) {
+	method := func(receiver, a Matrix) {
+		type ExpTrier interface {
+			Exp(a Triangular)
+		}
+		receiver.(ExpTrier).Exp(a.(Triangular))
+	}
+	denseComparison := func(receiver, a *Dense) {
+		receiver.Exp(a)
+	}
+	legalSizeTriMul := func(ar, ac int) bool {
+		// Need both to be square and the sizes to be the same
+		return ar == ac
+	}
+
+	// The legal types are triangles with the same TriKind.
+	// legalTypesTri returns whether both input arguments are Triangular.
+	legalTypes := func(a Matrix) bool {
+		if _, ok := a.(Triangular); !ok {
+			return false
+		}
+		return true
+	}
+	legalTypesLower := func(a Matrix) bool {
+		if !legalTypes(a) {
+			return false
+		}
+		_, kind := a.(Triangular).Triangle()
+		r := kind == matrix.Lower
+		return r
+	}
+
+	for _, receiver := range []*TriDense{
+		NewTriDense(2, matrix.Lower, []float64{0, 0, 2, 0}),
+		NewTriDense(2, matrix.Lower, []float64{1, 0, 2, 1}),
+		NewTriDense(3, matrix.Lower, []float64{0, 0, 0, 2, 0, 0, 3, 4, 0}),
+		NewTriDense(3, matrix.Lower, []float64{1, 0, 0, 2, 1, 0, 3, 4, 1}),
+		NewTriDense(4, matrix.Lower, []float64{0, 0, 0, 0, 2, 0, 0, 0, 3, 4, 0, 0, 5, 6, 7, 0}),
+		NewTriDense(4, matrix.Lower, []float64{1, 0, 0, 0, 2, 1, 0, 0, 3, 4, 1, 0, 5, 6, 7, 1})} {
+
+		testOneInput(t, "Exp", receiver, method, denseComparison, legalTypesLower, legalSizeTriMul, 1e-12)
+
+	}
+}

--- a/mat64/triangular_test.go
+++ b/mat64/triangular_test.go
@@ -347,16 +347,19 @@ func TestTriExp(t *testing.T) {
 		r := kind == matrix.Lower
 		return r
 	}
+	legalTypesUpper := func(a Matrix) bool {
+		if !legalTypes(a) {
+			return false
+		}
+		_, kind := a.(Triangular).Triangle()
+		r := kind == matrix.Upper
+		return r
+	}
 
-	for _, receiver := range []*TriDense{
-		NewTriDense(2, matrix.Lower, []float64{0, 0, 2, 0}),
-		NewTriDense(2, matrix.Lower, []float64{1, 0, 2, 1}),
-		NewTriDense(3, matrix.Lower, []float64{0, 0, 0, 2, 0, 0, 3, 4, 0}),
-		NewTriDense(3, matrix.Lower, []float64{1, 0, 0, 2, 1, 0, 3, 4, 1}),
-		NewTriDense(4, matrix.Lower, []float64{0, 0, 0, 0, 2, 0, 0, 0, 3, 4, 0, 0, 5, 6, 7, 0}),
-		NewTriDense(4, matrix.Lower, []float64{1, 0, 0, 0, 2, 1, 0, 0, 3, 4, 1, 0, 5, 6, 7, 1})} {
-
-		testOneInput(t, "Exp", receiver, method, denseComparison, legalTypesLower, legalSizeTriMul, 1e-12)
-
+	for n := 0; n < 8; n++ {
+		receiver := NewTriDense(n, matrix.Lower, nil)
+		testOneInput(t, "Exp", receiver, method, denseComparison, legalTypesLower, legalSizeTriMul, 1e-14)
+		receiver = NewTriDense(n, matrix.Upper, nil)
+		testOneInput(t, "Exp", receiver, method, denseComparison, legalTypesUpper, legalSizeTriMul, 1e-14)
 	}
 }


### PR DESCRIPTION
Implements #419 by using cool properties of triangular matrices which have a size of powers of two (1, 2, 4, 8, ...).

*Note:* This is my first contribution of gonum, so it's very likely that I'm misusing many of the internal functions provided in the library. For example, I may be wrong in understanding that `testOneInput` generates random matrices based on the provided type and size.