### PR TITLE
mat64: add generalised singular value decomposition

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -14,7 +14,7 @@ const (
 	Lower TriKind = false
 )
 
-// SVDKind specifies the treatment of singular vectors during the
+// SVDKind specifies the treatment of singular vectors during an SVD
 // factorization.
 type SVDKind int
 
@@ -31,4 +31,24 @@ const (
 	//  A = U * Σ * V^T
 	// where U is of size m×m, Σ is an m×n diagonal matrix, and V is an n×n matrix.
 	SVDFull
+)
+
+// GSVDKind specifies the treatment of singular vectors during a GSVD
+// factorization.
+type GSVDKind int
+
+const (
+	// GSVDU specifies that the U singular vectors should be computed during
+	// the decomposition.
+	GSVDU GSVDKind = 1 << iota
+	// GSVDV specifies that the V singular vectors should be computed during
+	// the decomposition.
+	GSVDV
+	// GSVDQ specifies that the Q singular vectors should be computed during
+	// the decomposition.
+	GSVDQ
+
+	// GSVDNone specifies that no singular vector should be computed during
+	// the decomposition.
+	GSVDNone
 )

--- a/mat64/cholesky_test.go
+++ b/mat64/cholesky_test.go
@@ -117,6 +117,67 @@ func TestCholeskySolve(t *testing.T) {
 	}
 }
 
+func TestSolveTwoChol(t *testing.T) {
+	for _, test := range []struct {
+		a, b *SymDense
+	}{
+		{
+			a: NewSymDense(2, []float64{
+				1, 0,
+				0, 1,
+			}),
+			b: NewSymDense(2, []float64{
+				1, 0,
+				0, 1,
+			}),
+		},
+		{
+			a: NewSymDense(2, []float64{
+				1, 0,
+				0, 1,
+			}),
+			b: NewSymDense(2, []float64{
+				2, 0,
+				0, 2,
+			}),
+		},
+		{
+			a: NewSymDense(3, []float64{
+				53, 59, 37,
+				59, 83, 71,
+				37, 71, 101,
+			}),
+			b: NewSymDense(3, []float64{
+				2, -1, 0,
+				-1, 2, -1,
+				0, -1, 2,
+			}),
+		},
+	} {
+		var chola, cholb Cholesky
+		ok := chola.Factorize(test.a)
+		if !ok {
+			t.Fatal("unexpected Cholesky factorization failure for a: not positive definite")
+		}
+		ok = cholb.Factorize(test.b)
+		if !ok {
+			t.Fatal("unexpected Cholesky factorization failure for b: not positive definite")
+		}
+
+		var x Dense
+		x.solveTwoChol(&chola, &cholb)
+
+		var ans Dense
+		ans.Mul(test.a, &x)
+		if !EqualApprox(&ans, test.b, 1e-12) {
+			var y Dense
+			y.Solve(test.a, test.b)
+			t.Errorf("incorrect Cholesky solve solution product\ngot solution:\n%.4v\nwant solution\n%.4v",
+				Formatted(&x), Formatted(&y))
+		}
+	}
+}
+
 func TestCholeskySolveVec(t *testing.T) {
 	for _, test := range []struct {
 		a   *SymDense

--- a/mat64/gsvd.go
+++ b/mat64/gsvd.go
@@ -1,0 +1,321 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// Based on the SingularValueDecomposition class from Jama 1.0.3.
+
+package mat64
+
+import (
+	"github.com/gonum/blas/blas64"
+	"github.com/gonum/floats"
+	"github.com/gonum/lapack"
+	"github.com/gonum/lapack/lapack64"
+	"github.com/gonum/matrix"
+)
+
+// GSVD is a type for creating and using the Generalized Singular Value Decomposition
+// (GSVD) of a matrix. See Factorize for a description of the decomposition.
+type GSVD struct {
+	kind matrix.GSVDKind
+
+	r, p, c, k, l int
+	s1, s2        []float64
+	a, b, u, v, q blas64.General
+
+	work  []float64
+	iwork []int
+}
+
+// Factorize computes the generalized singular value decomposition (GSVD) of the input
+// the r×c matrix A and the p×c matrix B. The singular values of A and B are computed
+// in all cases, while the singular vectors are optionally computed depending on the
+// input kind.
+//
+// The full singular value decomposition (kind == GSVDU|GSVDV|GSVDQ) deconstructs A and B as
+//  A = U * Σ₁ * [ 0 R ] * Q^T
+//
+//  B = V * Σ₂ * [ 0 R ] * Q^T
+// where Σ₁ and Σ₂ are r×(k+l) and p×(k+l) diagonal matrices of singular values, and
+// U, V and Q are r×r, p×p and c×c orthogonal matrices of singular vectors. k+l is the
+// effective numerical rank of the matrix [ A^T B^T ]^T.
+//
+// It is frequently not necessary to compute the full GSVD. Computation time and
+// storage costs can be reduced using the appropriate kind. Either only the singular
+// values can be computed (kind == SVDNone), or in conjunction with specific singular
+// vectors (kind bit set according to matrix.GSVDU, matrix.GSVDV and matrix.GSVDQ).
+//
+// Factorize returns whether the decomposition succeeded. If the decomposition
+// failed, routines that require a successful factorization will panic.
+func (gsvd *GSVD) Factorize(a, b Matrix, kind matrix.GSVDKind) (ok bool) {
+	r, c := a.Dims()
+	gsvd.r, gsvd.c = r, c
+	p, c := b.Dims()
+	gsvd.p = p
+	if gsvd.c != c {
+		panic(matrix.ErrShape)
+	}
+	var jobU, jobV, jobQ lapack.GSVDJob
+	switch {
+	default:
+		panic("gsvd: bad input kind")
+	case kind == matrix.GSVDNone:
+		jobU = lapack.GSVDNone
+		jobV = lapack.GSVDNone
+		jobQ = lapack.GSVDNone
+	case (matrix.GSVDU|matrix.GSVDV|matrix.GSVDQ)&kind != 0:
+		if matrix.GSVDU&kind != 0 {
+			jobU = lapack.GSVDU
+			gsvd.u = blas64.General{
+				Rows:   r,
+				Cols:   r,
+				Stride: r,
+				Data:   use(gsvd.u.Data, r*r),
+			}
+		}
+		if matrix.GSVDV&kind != 0 {
+			jobV = lapack.GSVDV
+			gsvd.v = blas64.General{
+				Rows:   p,
+				Cols:   p,
+				Stride: p,
+				Data:   use(gsvd.v.Data, p*p),
+			}
+		}
+		if matrix.GSVDQ&kind != 0 {
+			jobQ = lapack.GSVDQ
+			gsvd.q = blas64.General{
+				Rows:   c,
+				Cols:   c,
+				Stride: c,
+				Data:   use(gsvd.q.Data, c*c),
+			}
+		}
+	}
+
+	// A and B are destroyed on call, so copy the matrices.
+	aCopy := DenseCopyOf(a)
+	bCopy := DenseCopyOf(b)
+
+	gsvd.s1 = use(gsvd.s1, c)
+	gsvd.s2 = use(gsvd.s2, c)
+
+	gsvd.iwork = useInt(gsvd.iwork, c)
+
+	gsvd.work = use(gsvd.work, 1)
+	lapack64.Ggsvd3(jobU, jobV, jobQ, aCopy.mat, bCopy.mat, gsvd.s1, gsvd.s2, gsvd.u, gsvd.v, gsvd.q, gsvd.work, -1, gsvd.iwork)
+	gsvd.work = use(gsvd.work, int(gsvd.work[0]))
+	gsvd.k, gsvd.l, ok = lapack64.Ggsvd3(jobU, jobV, jobQ, aCopy.mat, bCopy.mat, gsvd.s1, gsvd.s2, gsvd.u, gsvd.v, gsvd.q, gsvd.work, len(gsvd.work), gsvd.iwork)
+	if ok {
+		gsvd.a = aCopy.mat
+		gsvd.b = bCopy.mat
+		gsvd.kind = kind
+	}
+	return ok
+}
+
+// Kind returns the matrix.GSVDKind of the decomposition. If no decomposition has been
+// computed, Kind returns 0.
+func (gsvd *GSVD) Kind() matrix.GSVDKind {
+	return gsvd.kind
+}
+
+// Rank returns the k and l terms of the rank of [ A^T B^T ]^T.
+func (gsvd *GSVD) Rank() (k, l int) {
+	return gsvd.k, gsvd.l
+}
+
+// GeneralizedValues returns the generalized singular values of the factorized matrices.
+// If the input slice is non-nil, the values will be stored in-place into the slice.
+// In this case, the slice must have length min(r,c)-k, and GeneralizedValues will
+// panic with matrix.ErrSliceLengthMismatch otherwise. If the input slice is nil,
+// a new slice of the appropriate length will be allocated and returned.
+//
+// GeneralizedValues will panic if the receiver does not contain a successful factorization.
+func (gsvd *GSVD) GeneralizedValues(v []float64) []float64 {
+	if gsvd.kind == 0 {
+		panic("gsvd: no decomposition computed")
+	}
+	r := gsvd.r
+	c := gsvd.c
+	k := gsvd.k
+	d := min(r, c)
+	if v == nil {
+		v = make([]float64, d-k)
+	}
+	if len(v) != d-k {
+		panic(matrix.ErrSliceLengthMismatch)
+	}
+	floats.DivTo(v, gsvd.s1[k:d], gsvd.s2[k:d])
+	return v
+}
+
+// ValuesA returns the singular values of the factorized A matrix.
+// If the input slice is non-nil, the values will be stored in-place into the slice.
+// In this case, the slice must have length min(r,c)-k, and ValuesA will panic with
+// matrix.ErrSliceLengthMismatch otherwise. If the input slice is nil,
+// a new slice of the appropriate length will be allocated and returned.
+//
+// ValuesA will panic if the receiver does not contain a successful factorization.
+func (gsvd *GSVD) ValuesA(s []float64) []float64 {
+	if gsvd.kind == 0 {
+		panic("gsvd: no decomposition computed")
+	}
+	r := gsvd.r
+	c := gsvd.c
+	k := gsvd.k
+	d := min(r, c)
+	if s == nil {
+		s = make([]float64, d-k)
+	}
+	if len(s) != d-k {
+		panic(matrix.ErrSliceLengthMismatch)
+	}
+	copy(s, gsvd.s1[k:min(r, c)])
+	return s
+}
+
+// ValuesB returns the singular values of the factorized B matrix.
+// If the input slice is non-nil, the values will be stored in-place into the slice.
+// In this case, the slice must have length min(r,c)-k, and ValuesB will panic with
+// matrix.ErrSliceLengthMismatch otherwise. If the input slice is nil,
+// a new slice of the appropriate length will be allocated and returned.
+//
+// ValuesB will panic if the receiver does not contain a successful factorization.
+func (gsvd *GSVD) ValuesB(s []float64) []float64 {
+	if gsvd.kind == 0 {
+		panic("gsvd: no decomposition computed")
+	}
+	r := gsvd.r
+	c := gsvd.c
+	k := gsvd.k
+	d := min(r, c)
+	if s == nil {
+		s = make([]float64, d-k)
+	}
+	if len(s) != d-k {
+		panic(matrix.ErrSliceLengthMismatch)
+	}
+	copy(s, gsvd.s2[k:d])
+	return s
+}
+
+// ZeroRFromGSVD extracts the matrix [ 0 R ] from the singular value decomposition, storing
+// the result in-place into the receiver. [ 0 R ] is size (k+l)×c.
+func (m *Dense) ZeroRFromGSVD(gsvd *GSVD) {
+	if gsvd.kind == 0 {
+		panic("gsvd: no decomposition computed")
+	}
+	r := gsvd.r
+	c := gsvd.c
+	k := gsvd.k
+	l := gsvd.l
+	h := min(k+l, r)
+	m.reuseAsZeroed(k+l, c)
+	a := Dense{
+		mat:     gsvd.a,
+		capRows: r,
+		capCols: c,
+	}
+	m.Slice(0, h, c-k-l, c).(*Dense).
+		Copy(a.Slice(0, h, c-k-l, c))
+	if r < k+l {
+		b := Dense{
+			mat:     gsvd.b,
+			capRows: gsvd.p,
+			capCols: c,
+		}
+		m.Slice(r, k+l, c+r-k-l, c).(*Dense).
+			Copy(b.Slice(r-k, l, c+r-k-l, c))
+	}
+}
+
+// SigmaAFromGSVD extracts the matrix Σ₁ from the singular value decomposition, storing
+// the result in-place into the receiver. Σ₁ is size r×(k+l).
+func (m *Dense) SigmaAFromGSVD(gsvd *GSVD) {
+	if gsvd.kind == 0 {
+		panic("gsvd: no decomposition computed")
+	}
+	r := gsvd.r
+	k := gsvd.k
+	l := gsvd.l
+	m.reuseAsZeroed(r, k+l)
+	for i := 0; i < k; i++ {
+		m.set(i, i, 1)
+	}
+	for i := k; i < min(r, k+l); i++ {
+		m.set(i, i, gsvd.s1[i])
+	}
+}
+
+// SigmaBFromGSVD extracts the matrix Σ₂ from the singular value decomposition, storing
+// the result in-place into the receiver. Σ₂ is size p×(k+l).
+func (m *Dense) SigmaBFromGSVD(gsvd *GSVD) {
+	if gsvd.kind == 0 {
+		panic("gsvd: no decomposition computed")
+	}
+	r := gsvd.r
+	p := gsvd.p
+	k := gsvd.k
+	l := gsvd.l
+	m.reuseAsZeroed(p, k+l)
+	for i := 0; i < min(l, r-k); i++ {
+		m.set(i, i+k, gsvd.s2[k+i])
+	}
+	for i := r - k; i < l; i++ {
+		m.set(i, i+k, 1)
+	}
+}
+
+// UFromGSVD extracts the matrix U from the singular value decomposition, storing
+// the result in-place into the receiver. U is size r×r.
+func (m *Dense) UFromGSVD(gsvd *GSVD) {
+	if gsvd.kind&matrix.GSVDU == 0 {
+		panic("mat64: improper GSVD kind")
+	}
+	r := gsvd.u.Rows
+	c := gsvd.u.Cols
+	m.reuseAs(r, c)
+
+	tmp := &Dense{
+		mat:     gsvd.u,
+		capRows: r,
+		capCols: c,
+	}
+	m.Copy(tmp)
+}
+
+// VFromGSVD extracts the matrix V from the singular value decomposition, storing
+// the result in-place into the receiver. V is size p×p.
+func (m *Dense) VFromGSVD(gsvd *GSVD) {
+	if gsvd.kind&matrix.GSVDV == 0 {
+		panic("mat64: improper GSVD kind")
+	}
+	r := gsvd.v.Rows
+	c := gsvd.v.Cols
+	m.reuseAs(r, c)
+
+	tmp := &Dense{
+		mat:     gsvd.v,
+		capRows: r,
+		capCols: c,
+	}
+	m.Copy(tmp)
+}
+
+// QFromGSVD extracts the matrix Q from the singular value decomposition, storing
+// the result in-place into the receiver. Q is size c×c.
+func (m *Dense) QFromGSVD(gsvd *GSVD) {
+	if gsvd.kind&matrix.GSVDQ == 0 {
+		panic("mat64: improper GSVD kind")
+	}
+	r := gsvd.q.Rows
+	c := gsvd.q.Cols
+	m.reuseAs(r, c)
+
+	tmp := &Dense{
+		mat:     gsvd.q,
+		capRows: r,
+		capCols: c,
+	}
+	m.Copy(tmp)
+}

--- a/mat64/gsvd_test.go
+++ b/mat64/gsvd_test.go
@@ -1,0 +1,119 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mat64
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/gonum/floats"
+	"github.com/gonum/matrix"
+)
+
+func TestGSVD(t *testing.T) {
+	const tol = 1e-10
+	rnd := rand.New(rand.NewSource(1))
+	for _, test := range []struct {
+		m, p, n int
+	}{
+		{5, 3, 5},
+		{5, 3, 3},
+		{3, 3, 5},
+		{5, 5, 5},
+		{5, 5, 3},
+		{3, 5, 5},
+		{150, 150, 150},
+		{200, 150, 150},
+		{150, 150, 200},
+		{150, 200, 150},
+		{200, 200, 150},
+		{150, 200, 200},
+	} {
+		m := test.m
+		p := test.p
+		n := test.n
+		for trial := 0; trial < 10; trial++ {
+			a := NewDense(m, n, nil)
+			for i := range a.mat.Data {
+				a.mat.Data[i] = rnd.NormFloat64()
+			}
+			aCopy := DenseCopyOf(a)
+
+			b := NewDense(p, n, nil)
+			for i := range b.mat.Data {
+				b.mat.Data[i] = rnd.NormFloat64()
+			}
+			bCopy := DenseCopyOf(b)
+
+			// Test Full decomposition.
+			var gsvd GSVD
+			ok := gsvd.Factorize(a, b, matrix.GSVDU|matrix.GSVDV|matrix.GSVDQ)
+			if !ok {
+				t.Errorf("GSVD factorization failed")
+			}
+			if !Equal(a, aCopy) {
+				t.Errorf("A changed during call to GSVD.Factorize with GSVDU|GSVDV|GSVDQ")
+			}
+			if !Equal(b, bCopy) {
+				t.Errorf("B changed during call to GSVD.Factorize with GSVDU|GSVDV|GSVDQ")
+			}
+			c, s, sigma1, sigma2, zeroR, u, v, q := extractGSVD(&gsvd)
+			var ansU, ansV, d1R, d2R Dense
+			ansU.Product(u.T(), a, q)
+			ansV.Product(v.T(), b, q)
+			d1R.Mul(sigma1, zeroR)
+			d2R.Mul(sigma2, zeroR)
+			if !EqualApprox(&ansU, &d1R, tol) {
+				t.Errorf("Answer mismatch with GSVDU|GSVDV|GSVDQ\nU^T * A * Q:\n% 0.2f\nΣ₁ * [ 0 R ]:\n% 0.2f",
+					Formatted(&ansU), Formatted(&d1R))
+			}
+			if !EqualApprox(&ansV, &d2R, tol) {
+				t.Errorf("Answer mismatch with GSVDU|GSVDV|GSVDQ\nV^T * B  *Q:\n% 0.2f\nΣ₂ * [ 0 R ]:\n% 0.2f",
+					Formatted(&d2R), Formatted(&ansV))
+			}
+
+			// Check C^2 + S^2 = I.
+			for i := range c {
+				d := c[i]*c[i] + s[i]*s[i]
+				if !floats.EqualWithinAbsOrRel(d, 1, 1e-14, 1e-14) {
+					t.Errorf("c_%d^2 + s_%d^2 != 1: got: %v", i, i, d)
+				}
+			}
+
+			// Test None decomposition.
+			ok = gsvd.Factorize(a, b, matrix.GSVDNone)
+			if !ok {
+				t.Errorf("GSVD factorization failed")
+			}
+			if !Equal(a, aCopy) {
+				t.Errorf("A changed during call to GSVD with GSVDNone")
+			}
+			if !Equal(b, bCopy) {
+				t.Errorf("B changed during call to GSVD with GSVDNone")
+			}
+			cNone := gsvd.ValuesA(nil)
+			if !floats.EqualApprox(c, cNone, tol) {
+				t.Errorf("Singular value mismatch between GSVDU|GSVDV|GSVDQ and GSVDNone decomposition")
+			}
+			sNone := gsvd.ValuesB(nil)
+			if !floats.EqualApprox(s, sNone, tol) {
+				t.Errorf("Singular value mismatch between GSVDU|GSVDV|GSVDQ and GSVDNone decomposition")
+			}
+		}
+	}
+}
+
+func extractGSVD(gsvd *GSVD) (c, s []float64, s1, s2, zR, u, v, q *Dense) {
+	var s1m, s2m, zeroR, um, vm, qm Dense
+	s1m.SigmaAFromGSVD(gsvd)
+	s2m.SigmaBFromGSVD(gsvd)
+	zeroR.ZeroRFromGSVD(gsvd)
+	um.UFromGSVD(gsvd)
+	vm.VFromGSVD(gsvd)
+	qm.QFromGSVD(gsvd)
+	c = gsvd.ValuesA(nil)
+	s = gsvd.ValuesB(nil)
+	return c, s, &s1m, &s2m, &zeroR, &um, &vm, &qm
+}

--- a/mat64/hogsvd.go
+++ b/mat64/hogsvd.go
@@ -1,0 +1,197 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// Based on the SingularValueDecomposition class from Jama 1.0.3.
+
+package mat64
+
+import (
+	"errors"
+
+	"github.com/gonum/blas/blas64"
+	"github.com/gonum/matrix"
+)
+
+// HOGSVD is a type for creating and using the Higher Order Generalized Singular Value
+// Decomposition (HOGSVD) of a set of matrices. See Factorize for a description of the
+// decomposition.
+type HOGSVD struct {
+	n int
+	v *Dense
+	b []Dense
+
+	err error
+}
+
+// Factorize computes the higher order generalized singular value decomposition (HOGSVD)
+// of the n input r_i×c column tall matrices in m. HOGSV extends the GSVD case from 2 to n
+// input matrices.
+//
+//  M_0 = U_0 * Σ_0 * V^T
+//  M_1 = U_1 * Σ_1 * V^T
+//  .
+//  .
+//  .
+//  M_{n-1} = U_{n-1} * Σ_{n-1} * V^T
+//
+// where U_i are r_i×c matrices of singular vectors, Σ are c×c matrices singular values, and V
+// is a c×c matrix of singular vectors.
+//
+// Factorize returns whether the decomposition succeeded. If the decomposition
+// failed, routines that require a successful factorization will panic.
+func (gsvd *HOGSVD) Factorize(m ...Matrix) (ok bool) {
+	// Factorize performs the HOGSVD factorisation
+	// essentially as described by Ponnapalli et al.
+	// https://doi.org/10.1371/journal.pone.0028072
+
+	if len(m) < 2 {
+		panic("hogsvd: too few matrices")
+	}
+	gsvd.n = 0
+
+	r, c := m[0].Dims()
+	a := make([]Cholesky, len(m))
+	var ts SymDense
+	for i, d := range m {
+		rd, cd := d.Dims()
+		if rd < cd {
+			gsvd.err = matrix.ErrShape
+			return false
+		}
+		if rd > r {
+			r = rd
+		}
+		if cd != c {
+			panic(matrix.ErrShape)
+		}
+		ts.Reset()
+		ts.SymOuterK(1, d.T())
+		ok = a[i].Factorize(&ts)
+		if !ok {
+			gsvd.err = errors.New("hogsvd: cholesky decomposition failed")
+			return false
+		}
+	}
+
+	s := getWorkspace(c, c, true)
+	defer putWorkspace(s)
+	sij := getWorkspace(c, c, false)
+	defer putWorkspace(sij)
+	for i, ai := range a {
+		for _, aj := range a[i+1:] {
+			gsvd.err = sij.solveTwoChol(&ai, &aj)
+			if gsvd.err != nil {
+				return false
+			}
+			s.Add(s, sij)
+
+			gsvd.err = sij.solveTwoChol(&aj, &ai)
+			if gsvd.err != nil {
+				return false
+			}
+			s.Add(s, sij)
+		}
+	}
+	s.Scale(1/float64(len(m)*(len(m)-1)), s)
+
+	var eig Eigen
+	ok = eig.Factorize(s.T(), false, true)
+	if !ok {
+		gsvd.err = errors.New("hogsvd: eigen decomposition failed")
+		return false
+	}
+	v := eig.Vectors()
+	for j := 0; j < c; j++ {
+		cv := v.ColView(j)
+		cv.ScaleVec(1/blas64.Nrm2(c, cv.mat), cv)
+	}
+
+	b := make([]Dense, len(m))
+	biT := getWorkspace(c, r, false)
+	defer putWorkspace(biT)
+	for i, d := range m {
+		// All calls to reset will leave a zeroed
+		// matrix with capacity to store the result
+		// without additional allocation.
+		biT.Reset()
+		gsvd.err = biT.Solve(v, d.T())
+		if gsvd.err != nil {
+			return false
+		}
+		b[i].Clone(biT.T())
+	}
+
+	gsvd.n = len(m)
+	gsvd.v = v
+	gsvd.b = b
+	return true
+}
+
+// Err returns the reason for a factorization failure.
+func (gsvd *HOGSVD) Err() error {
+	return gsvd.err
+}
+
+// Len returns the number of matrices that have been factorized. If Len returns
+// zero, the factorization was not successful.
+func (gsvd *HOGSVD) Len() int {
+	return gsvd.n
+}
+
+// UFromHOGSVD extracts the matrix U_n from the singular value decomposition, storing
+// the result in-place into the receiver. U_n is size r×c.
+//
+// UFromHOGSVD will panic if the receiver does not contain a successful factorization.
+func (m *Dense) UFromHOGSVD(gsvd *HOGSVD, n int) {
+	if gsvd.n == 0 {
+		panic("hogsvd: unsuccessful factorization")
+	}
+	if n < 0 || gsvd.n <= n {
+		panic("hogsvd: invalid index")
+	}
+
+	m.reuseAs(gsvd.b[n].Dims())
+	m.Copy(&gsvd.b[n])
+	for j, f := range gsvd.Values(nil, n) {
+		v := m.ColView(j)
+		v.ScaleVec(1/f, v)
+	}
+}
+
+// Values returns the nth set of singular values of the factorized system.
+// If the input slice is non-nil, the values will be stored in-place into the slice.
+// In this case, the slice must have length c, and Values will panic with
+// matrix.ErrSliceLengthMismatch otherwise. If the input slice is nil,
+// a new slice of the appropriate length will be allocated and returned.
+//
+// Values will panic if the receiver does not contain a successful factorization.
+func (gsvd *HOGSVD) Values(s []float64, n int) []float64 {
+	if gsvd.n == 0 {
+		panic("hogsvd: unsuccessful factorization")
+	}
+	if n < 0 || gsvd.n <= n {
+		panic("hogsvd: invalid index")
+	}
+
+	r, c := gsvd.b[n].Dims()
+	if s == nil {
+		s = make([]float64, c)
+	} else if len(s) != c {
+		panic(matrix.ErrSliceLengthMismatch)
+	}
+	for j := 0; j < c; j++ {
+		s[j] = blas64.Nrm2(r, gsvd.b[n].ColView(j).mat)
+	}
+	return s
+}
+
+// VFromHOGSVD extracts the matrix V from the singular value decomposition, storing
+// the result in-place into the receiver. V is size c×c.
+//
+// VFromHOGSVD will panic if the receiver does not contain a successful factorization.
+func (m *Dense) VFromHOGSVD(gsvd *HOGSVD) {
+	if gsvd.n == 0 {
+		panic("hogsvd: unsuccessful factorization")
+	}
+	*m = *DenseCopyOf(gsvd.v)
+}

--- a/mat64/hogsvd_test.go
+++ b/mat64/hogsvd_test.go
@@ -1,0 +1,89 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mat64
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestHOGSVD(t *testing.T) {
+	const tol = 1e-10
+	rnd := rand.New(rand.NewSource(1))
+	for cas, test := range []struct {
+		r, c int
+	}{
+		{5, 3},
+		{5, 5},
+		{150, 150},
+		{200, 150},
+
+		// Calculating A_i*A_j^T and A_j*A_i^T fails for wide matrices.
+		{3, 5},
+	} {
+		r := test.r
+		c := test.c
+		for n := 3; n < 6; n++ {
+			data := make([]Matrix, n)
+			dataCopy := make([]*Dense, n)
+			for trial := 0; trial < 10; trial++ {
+				for i := range data {
+					d := NewDense(r, c, nil)
+					for j := range d.mat.Data {
+						d.mat.Data[j] = rnd.Float64()
+					}
+					data[i] = d
+					dataCopy[i] = DenseCopyOf(d)
+				}
+
+				var gsvd HOGSVD
+				ok := gsvd.Factorize(data...)
+				if r >= c {
+					if !ok {
+						t.Errorf("HOGSVD factorization failed for %d %d×%d matrices: %v", n, r, c, gsvd.Err())
+						continue
+					}
+				} else {
+					if ok {
+						t.Errorf("HOGSVD factorization unexpectedly succeeded for for %d %d×%d matrices", n, r, c)
+					}
+					continue
+				}
+				for i := range data {
+					if !Equal(data[i], dataCopy[i]) {
+						t.Errorf("A changed during call to HOGSVD.Factorize")
+					}
+				}
+				u, s, v := extractHOGSVD(&gsvd)
+				for i, want := range data {
+					var got Dense
+					sigma := NewDense(c, c, nil)
+					for j := 0; j < c; j++ {
+						sigma.Set(j, j, s[i][j])
+					}
+
+					got.Product(u[i], sigma, v.T())
+					if !EqualApprox(&got, want, tol) {
+						t.Errorf("test %d n=%d trial %d: unexpected answer\nU_%[4]d * S_%[4]d * V^T:\n% 0.2f\nD_%d:\n% 0.2f",
+							cas, n, trial, i, Formatted(&got, Excerpt(5)), i, Formatted(want, Excerpt(5)))
+					}
+				}
+			}
+		}
+	}
+}
+
+func extractHOGSVD(gsvd *HOGSVD) (u []*Dense, s [][]float64, v *Dense) {
+	u = make([]*Dense, gsvd.Len())
+	s = make([][]float64, gsvd.Len())
+	for i := 0; i < gsvd.Len(); i++ {
+		u[i] = &Dense{}
+		u[i].UFromHOGSVD(gsvd, i)
+		s[i] = gsvd.Values(nil, i)
+	}
+	v = &Dense{}
+	v.VFromHOGSVD(gsvd)
+	return u, s, v
+}

--- a/mat64/matrix.go
+++ b/mat64/matrix.go
@@ -883,3 +883,12 @@ func zero(f []float64) {
 		f[i] = 0
 	}
 }
+
+// useInt returns an int slice with l elements, using i if it
+// has the necessary capacity, otherwise creating a new slice.
+func useInt(i []int, l int) []int {
+	if l <= cap(i) {
+		return i[:l]
+	}
+	return make([]int, l)
+}


### PR DESCRIPTION
@btracey @vladimir-ch Please take a look.

Depends on https://github.com/gonum/lapack/pull/249.

This is functional, but I think the API is open for discussion for a few reasons.

1. Currently there is no interface for the user to gain the permuted alpha/vectors.
2. I would like to have HOGSVD (GSVD with more than 2 matrices) in the long run (this does not use LAPACK) and it's appealing to me to roll HOGSVD and GSVD together (so that they are actually generalised). This has some unfortunate issues, so may not be ideal.