### PR TITLE
mat64: deflake TestDet

### DIFF
--- a/mat64/list_test.go
+++ b/mat64/list_test.go
@@ -91,13 +91,15 @@ func sameAnswerFloat(a, b interface{}) bool {
 	return a.(float64) == b.(float64)
 }
 
-// sameAnswerFloatApprox returns whether the two inputs are both NaN or within tol
-// of each other.
-func sameAnswerFloatApprox(a, b interface{}) bool {
-	if math.IsNaN(a.(float64)) {
-		return math.IsNaN(b.(float64))
+// sameAnswerFloatApproxTol returns a function that determines whether its two
+// inputs are both NaN or within tol of each other.
+func sameAnswerFloatApproxTol(tol float64) func(a, b interface{}) bool {
+	return func(a, b interface{}) bool {
+		if math.IsNaN(a.(float64)) {
+			return math.IsNaN(b.(float64))
+		}
+		return floats.EqualWithinAbsOrRel(a.(float64), b.(float64), tol, tol)
 	}
-	return floats.EqualWithinAbsOrRel(a.(float64), b.(float64), 1e-12, 1e-12)
 }
 
 func sameAnswerF64SliceOfSlice(a, b interface{}) bool {

--- a/mat64/matrix_test.go
+++ b/mat64/matrix_test.go
@@ -275,7 +275,7 @@ func TestCond(t *testing.T) {
 		denseComparison := func(a *Dense) interface{} {
 			return Cond(a, test.norm)
 		}
-		testOneInputFunc(t, test.name, f, denseComparison, sameAnswerFloatApprox, isAnyType, isAnySize)
+		testOneInputFunc(t, test.name, f, denseComparison, sameAnswerFloatApproxTol(1e-12), isAnyType, isAnySize)
 	}
 }
 
@@ -325,7 +325,7 @@ func TestDet(t *testing.T) {
 	denseComparison := func(a *Dense) interface{} {
 		return Det(a)
 	}
-	testOneInputFunc(t, "Det", f, denseComparison, sameAnswerFloatApprox, isAnyType, isSquare)
+	testOneInputFunc(t, "Det", f, denseComparison, sameAnswerFloatApproxTol(1e-12), isAnyType, isSquare)
 
 	// Check that it gives approximately the same answer as Cholesky
 	// Ensure the input matrices are wider than tall so they are full rank
@@ -355,7 +355,7 @@ func TestDet(t *testing.T) {
 		}
 		return chol.Det()
 	}
-	testOneInputFunc(t, "DetVsChol", f, denseComparison, sameAnswerFloatApprox, isAnyType, isWide)
+	testOneInputFunc(t, "DetVsChol", f, denseComparison, sameAnswerFloatApproxTol(1e-10), isAnyType, isWide)
 }
 
 func TestDot(t *testing.T) {
@@ -376,7 +376,7 @@ func TestDot(t *testing.T) {
 		}
 		return sum
 	}
-	testTwoInputFunc(t, "Dot", f, denseComparison, sameAnswerFloatApprox, legalTypesVecVec, legalSizeSameVec)
+	testTwoInputFunc(t, "Dot", f, denseComparison, sameAnswerFloatApproxTol(1e-12), legalTypesVecVec, legalSizeSameVec)
 }
 
 func TestEqual(t *testing.T) {
@@ -463,7 +463,7 @@ func TestNorm(t *testing.T) {
 		denseComparison := func(a *Dense) interface{} {
 			return Norm(a, test.norm)
 		}
-		testOneInputFunc(t, test.name, f, denseComparison, sameAnswerFloatApprox, isAnyType, isAnySize)
+		testOneInputFunc(t, test.name, f, denseComparison, sameAnswerFloatApproxTol(1e-12), isAnyType, isAnySize)
 	}
 }
 
@@ -496,7 +496,7 @@ func TestSum(t *testing.T) {
 	denseComparison := func(a *Dense) interface{} {
 		return Sum(a)
 	}
-	testOneInputFunc(t, "Sum", f, denseComparison, sameAnswerFloatApprox, isAnyType, isAnySize)
+	testOneInputFunc(t, "Sum", f, denseComparison, sameAnswerFloatApproxTol(1e-12), isAnyType, isAnySize)
 }
 
 func TestTrace(t *testing.T) {


### PR DESCRIPTION
This allows 4000 tests of TestDet to pass, but the test is still flakey as it panics due to a Cholesky decomposition failure before 5000 tests.

@btracey Please take a look.

Updates #437.