### PR TITLE
improve the dense tranpose and add matnum package, it easy to use

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -132,6 +132,7 @@ var (
 	ErrSliceLengthMismatch = Error{"matrix: input slice length mismatch"}
 	ErrNotPSD              = Error{"matrix: input not positive symmetric definite"}
 	ErrFailedEigen         = Error{"matrix: eigendecomposition not successful"}
+	ErrTypeAssert	     = Error{"matrix: type assert error"}
 )
 
 // ErrorStack represents matrix handling errors that have been recovered by Maybe wrappers.

--- a/mat64/dense.go
+++ b/mat64/dense.go
@@ -198,7 +198,23 @@ func (m *Dense) Caps() (r, c int) { return m.capRows, m.capCols }
 
 // T performs an implicit transpose by returning the receiver inside a Transpose.
 func (m *Dense) T() Matrix {
-	return Transpose{m}
+	r, c := m.Dims()
+	data := make([]float64, r*c)
+	for i := 0; i < r; i++ {
+		for j := 0; j < c; j++ {
+			data[j*r+i] = m.mat.Data[i*c+j]
+		}
+	}
+	return &Dense{
+		mat: blas64.General{
+			Rows:   c,
+			Cols:   r,
+			Stride: r,
+			Data:   data,
+		},
+		capRows: c,
+		capCols: r,
+	}
 }
 
 // ColView returns a Vector reflecting the column j, backed by the matrix data.

--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -1871,6 +1871,12 @@ func TestInverse(t *testing.T) {
 	}
 }
 
+func TestTranspose(t *testing.T) {
+	dense := NewDense(3, 4, []float64{1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3})
+	dense_t := dense.T()
+	fmt.Println(dense_t)
+}
+
 var (
 	wd *Dense
 )

--- a/matnum/matrix.go
+++ b/matnum/matrix.go
@@ -1,0 +1,46 @@
+package matnum
+
+
+type Matrix interface {
+
+	// return the dimensions of matrix
+	Dims() (dim int)
+
+	// return the shape of matrix(rows and cols)
+	shape() (shapes []int)
+
+	// return the value of element from high dimension to low dimension
+	at(paras ...int) float64
+
+	// Set will give a number for certain position
+	set(val float64,paras ...int)
+
+	//copyto one matrix to another matrix
+	copyTo(mat Matrix)
+
+	//the Matrix transpose
+	T() Matrix
+
+	//multiply the matrix
+	Mul(matrixs ...Matrix) Matrix
+
+	//Add the matrix
+	Add(matrixs ...Matrix) Matrix
+
+	//Scale will scale the matrix
+	Scale(scale float64) Matrix
+
+	//Clone the Matrix
+	Clone() Matrix
+
+	//Slice return the sub matrix
+	//if the len(paras) == the len(dim) it will return error
+	Slice(paras ...[2]int) Matrix
+
+	//Append the Matrix dynamic
+	appendMatrix(matrix Matrix,flags ...int) Matrix
+
+	//Error indicator for chain rule(do not return the error from func)
+	Err() error
+
+}

--- a/matnum/matrix2d.go
+++ b/matnum/matrix2d.go
@@ -1,0 +1,366 @@
+//powered by BruceMarcus
+package matnum
+
+import (
+	"github.com/gonum/blas/blas64"
+	"github.com/gonum/matrix"
+)
+
+var (
+	matrix2d *Matrix2D_I
+	_        Matrix = matrix2d
+)
+
+type Matrix2D_I interface {
+	// implement the Matrix interface
+	Matrix
+
+	At(r,c int)  float64
+
+	CopyTo(mat Matrix2D_I)
+	Set(val float64,r,c int)
+	//return the shape
+	Shape() (r, c int)
+
+	Map(fn func(x float64) float64,val float64)
+
+	//Append for append the matrix2d
+	//0 indicate the row
+	//1 indicate the col
+	AppendMatrix(vector *Vector, flag int) Matrix2D_I
+}
+
+type Matrix2D struct {
+	mat blas64.General
+
+	capRows, capCols int
+
+	err error
+}
+
+func (mat2d *Matrix2D) Dims() (dim int) {
+	return 2
+}
+
+func (mat2d *Matrix2D) shape() (shapes []int) {
+	shapes = make([]int, 2)
+	shapes[0] = mat2d.mat.Rows
+	shapes[1] = mat2d.mat.Cols
+
+	return shapes
+}
+
+func (mat2d *Matrix2D) At(r,c int) float64 {
+	return mat2d.at(r,c)
+}
+
+func (mat2d *Matrix2D) at(paras ...int) float64 {
+	if len(paras) != 2 {
+		panic(matrix.ErrShape)
+	}
+
+	row_length := mat2d.mat.Rows
+	col_length := mat2d.mat.Cols
+	row := paras[0]
+	col := paras[1]
+
+	if row_length < row || col_length < col {
+		panic(matrix.ErrIndexOutOfRange)
+
+	}
+	return mat2d.mat.Data[row*mat2d.mat.Stride+col]
+}
+
+func (mat2d *Matrix2D) Set(val float64, r,c int) {
+	mat2d.set(val,r,c)
+}
+
+func (mat2d *Matrix2D) set(val float64, paras ...int) {
+	if len(paras) != 2 {
+		panic(matrix.ErrShape)
+	}
+
+	r, c := paras[0], paras[1]
+
+	mat2d.mat.Data[r*mat2d.mat.Stride+c] = val
+}
+
+func (mat2d *Matrix2D) T() Matrix {
+	r, c := mat2d.Shape()
+	data := make([]float64, r*c)
+	for i := 0; i < r; i++ {
+		for j := 0; j < c; j++ {
+			data[j*r+i] = mat2d.At(r, c)
+		}
+	}
+	return &Matrix2D{
+		mat: blas64.General{
+			Rows:   c,
+			Cols:   r,
+			Stride: r,
+			Data:   data,
+		},
+		capRows: c,
+		capCols: r,
+		err:     nil,
+	}
+}
+
+func (mat2d *Matrix2D) Mul(matrixs ...Matrix) Matrix {
+	switch len(matrixs) {
+	case 0:
+		panic(matrix.ErrShape)
+	case 1:
+		if mat, ok := matrixs[0].(Matrix2D_I); ok {
+			mat2d.mulElem(mat)
+		} else if vec,ok := matrix[0].(*Vector);ok {
+			mat2d.mulElem(vec)
+			panic(matrix.ErrTypeAssert)
+		}
+	}
+	matrixs2d_slice := make([]Matrix2D_I, len(matrixs))
+	for i, arg := range matrixs {
+		matrixs2d_slice[i] = arg.(Matrix2D_I)
+	}
+	p := newMultiplier(mat2d, matrixs2d_slice...)
+	p.optimize()
+	result := p.multiply()
+
+	return result
+}
+
+func (mat2d *Matrix2D) Add(matrixs ...Matrix) Matrix {
+	ar, ac := mat2d.Shape()
+	data := make([]float64, ar*ac)
+	for _, e := range matrixs {
+		if mat, ok := e.(Matrix2D_I); ok {
+			br, bc := mat.Shape()
+			if br != ar || bc != ac {
+				panic(matrix.ErrShape)
+			}
+			for r := 0; r < ar; r++ {
+				for c := 0; c < ac; c++ {
+					data[r*ac+ar] += mat.At(r, c)
+				}
+			}
+		} else {
+			panic(matrix.ErrTypeAssert)
+		}
+	}
+	return &Matrix2D{
+		mat: blas64.General{
+			Rows:   ar,
+			Cols:   ac,
+			Stride: ac,
+			Data:   data,
+		},
+		capRows: ar,
+		capCols: ac,
+		err:     nil,
+	}
+}
+
+func (mat2d *Matrix2D) Scale(scale float64) Matrix {
+	ar, ac := mat2d.Shape()
+	data := make([]float64, ar*ac)
+	for r := 0; r < ar; r++ {
+		for c := 0; c < ac; c++ {
+			data[r*ac+c] = mat2d.At(r, c) * scale
+		}
+	}
+	return &Matrix2D{
+		mat: blas64.General{
+			Rows:   ar,
+			Cols:   ac,
+			Stride: ac,
+			Data:   data,
+		},
+		capRows: ar,
+		capCols: ac,
+		err:     nil,
+	}
+}
+
+func (mat2d *Matrix2D) Clone() Matrix {
+	ar, ac := mat2d.Shape()
+	data := make([]float64, ar*ac)
+	for r := 0; r < ar; r++ {
+		for c := 0; c < ac; c++ {
+			data[r*ac+c] = mat2d.At(r, c)
+		}
+	}
+	return &Matrix2D{
+		mat: blas64.General{
+			Rows:   ar,
+			Cols:   ac,
+			Stride: ac,
+			Data:   data,
+		},
+		capRows: ar,
+		capCols: ac,
+		err:     nil,
+	}
+}
+
+func (mat2d *Matrix2D) copyTo(mat Matrix) {
+	if bm,ok := mat.(Matrix2D_I);ok {
+		ar,ac := mat2d.Shape()
+		br,bc := bm.Shape()
+		if ar != br || ac != bc {
+			panic(matrix.ErrShape)
+		}
+		for r:=0;r<ar;r++ {
+			for c:=0;c<ac;c++{
+				bm.At(r,c) = mat2d.At(r,c)
+			}
+		}
+	}
+}
+
+func (mat2d *Matrix2D) CopyTo(mat Matrix2D_I) {
+	mat2d.copyTo(mat)
+}
+
+func (mat2d *Matrix2D) Slice(paras ...[2]int) Matrix {
+	if len(paras) != 2 {
+		panic(matrix.ErrShape)
+	}
+	ar, ac := mat2d.Shape()
+	br, brl := paras[0][0], paras[0][1]
+	bc, bcl := paras[1][0], paras[1][1]
+	if br < 0 || bc < 0 || brl < 1 || bcl < 1 || br+brl > ar || bc+bcl > ac {
+		panic(matrix.ErrShape)
+	}
+	t := *mat2d
+	t.mat.Data = mat2d.mat.Data[br*mat2d.mat.Stride+bc : (br+brl)*mat2d.mat.Stride+bc+bcl]
+	t.mat.Rows = brl
+	t.mat.Cols = bcl
+	t.capRows -= br
+	t.capCols -= bc
+
+	return &t
+}
+
+func (mat2d *Matrix2D) Map(fn func(x float64) float64,val float64) {
+	ar,ac := mat2d.Shape()
+	for r:=0;r<ar;r++ {
+		for c:=0;c<ac;c++{
+			mat2d.Set(fn(val),r,c)
+		}
+	}
+}
+
+func (mat2d *Matrix2D) appendMatrix(mat Matrix, flags ...int) Matrix {
+	if vec,ok := mat.(*Vector);ok {
+		ar,ac := mat2d.Shape()
+		if flags[0] == 0 {
+			if vec.Shape() != ac {
+				panic(matrix.ErrShape)
+			}
+			data := make([]float64,(ar+1)*ac)
+			for r:=0;r<ar;r++ {
+				for c:=0;c<ac;c++ {
+					data[r*ac+c] = mat2d.At(r,c)
+				}
+			}
+			for index:=0;index<ac;index++ {
+				data[ar*ac + index] = vec.At(index)
+			}
+			return &Matrix2D{
+				mat: blas64.General{
+					Rows:   ar+1,
+					Cols:   ac,
+					Stride: ac,
+					Data:   data,
+				},
+				capRows: ar+1,
+				capCols: ac,
+				err:     nil,
+			}
+		} else if flags[0] == 1{
+			if vec.Shape() != ar {
+				panic(matrix.ErrShape)
+			}
+			data := make([]float64,ar*(ac+1))
+			for r:=0;r<ar;r++ {
+				for c:=0;c<ac;c++ {
+					data[r*ac+c] = mat2d.At(r,c)
+				}
+			}
+			for index:=0;index<ar;index++ {
+				data[index*(ac+1) + ac+1] = vec.At(index)
+			}
+			return &Matrix2D{
+				mat: blas64.General{
+					Rows:   ar,
+					Cols:   ac+1,
+					Stride: ac+1,
+					Data:   data,
+				},
+				capRows: ar,
+				capCols: ac+1,
+				err:     nil,
+			}
+
+		} else {
+			panic(matrix.ErrShape)
+		}
+	}else{
+		panic(matrix.ErrTypeAssert)
+	}
+
+}
+
+func (mat2d *Matrix2D) Err() error {
+	return mat2d.err
+}
+
+func (mat2d *Matrix2D) Shape() (r, c int) {
+	return mat2d.shape()[0],mat2d.shape()[1]
+}
+
+func (mat2d *Matrix2D) AppendMatrix(vector *Vector, flag int) Matrix2D_I{
+	return mat2d.appendMatrix(vector,flag).(Matrix2D_I)
+}
+
+func (mat2d *Matrix2D) mulElem(mat Matrix) *Matrix2D {
+	ar, ac := mat2d.Shape()
+	var br,bc int
+	if vec,ok := mat.(*Vector);ok {
+		br = vec.Shape()
+		bc = 1
+	}
+	if mat,ok := mat.(Matrix2D_I);ok {
+		br,bc = mat.Shape()
+	} else {
+		panic(matrix.ErrTypeAssert)
+	}
+	if ac != br {
+		panic(matrix.ErrShape)
+	}
+	data := make([]float64, ar*bc)
+	row := make([]float64, ac)
+	for r := 0; r < ar; r++ {
+		for i := range row {
+			row[i] = mat2d.At(r, i)
+		}
+		for c := 0; c < bc; c++ {
+			var v float64
+			for i, e := range row {
+				v += e * mat.at(i, c)
+			}
+			data[r*bc+c] = v
+		}
+	}
+	return &Matrix2D{
+		mat: blas64.General{
+			Rows:   ar,
+			Cols:   bc,
+			Stride: bc,
+			Data:   data,
+		},
+		capRows: ar,
+		capCols: ac,
+		err:     nil,
+	}
+}

--- a/matnum/multiply.go
+++ b/matnum/multiply.go
@@ -1,0 +1,108 @@
+package matnum
+
+import (
+	"github.com/gonum/matrix"
+	"math"
+)
+
+type multiplier struct {
+	// factors is the ordered set of
+	// factors to multiply.
+	factors []Matrix2D_I
+	// dims is the chain of factor
+	// dimensions.
+	dims []int
+
+	// table contains the dynamic
+	// programming costs and subchain
+	// division indices.
+	table table
+}
+
+func newMultiplier(m Matrix2D_I,factors ...Matrix2D_I) *multiplier {
+	ar,ac := m.Shape()
+	if ar == 0 || ac == 0 {
+		panic(matrix.ErrShape)
+	}
+
+
+	dims := make([]int,len(factors)+2)
+	dims[0] = ar
+	dims[1] = ac
+	for i:=0;i<len(factors);i++ {
+		br,bc := factors[i].Shape()
+		if br != dims[i+1] {
+			panic(matrix.ErrShape)
+		}
+		dims[i+2] = bc
+	}
+	factor_head := []Matrix2D_I{m}
+	factor_end := append(factor_head,factors...)
+
+	return &multiplier{
+		factors: factor_end,
+		dims : dims,
+		table: newTable(len(factor_end)),
+	}
+
+}
+
+func (p *multiplier) optimize() {
+	const maxInt = math.MaxInt64
+	for f := 1; f < len(p.factors); f++ {
+		for i := 0; i < len(p.factors)-f; i++ {
+			j := i + f
+			p.table.set(i, j, entry{cost: maxInt})
+			for k := i; k < j; k++ {
+				cost := p.table.at(i, k).cost + p.table.at(k+1, j).cost + p.dims[i]*p.dims[k+1]*p.dims[j+1]
+				if cost < p.table.at(i, j).cost {
+					p.table.set(i, j, entry{cost: cost, k: k})
+				}
+			}
+		}
+	}
+}
+func (p *multiplier) multiply() Matrix2D_I {
+	result, _ := p.multiplySubchain(0, len(p.factors)-1)
+	return result
+}
+
+func (p *multiplier) multiplySubchain(i, j int) (m Matrix2D_I, intermediate bool) {
+	if i == j {
+		return p.factors[i], false
+	}
+
+	a, _ := p.multiplySubchain(i, p.table.at(i, j).k)
+	b, _ := p.multiplySubchain(p.table.at(i, j).k+1, j)
+
+	_, ac := a.Shape()
+	br, _ := b.Shape()
+	if ac != br {
+		// Panic with a string since this
+		// is not a user-facing panic.
+		panic(matrix.ErrShape.Error())
+	}
+
+	r := a.Mul(b)
+	return r.(Matrix2D_I), true
+}
+
+type entry struct {
+	k    int // is the chain subdivision index.
+	cost int // cost is the cost of the operation.
+}
+
+// table is a row major n×n dynamic programming table.
+type table struct {
+	n       int
+	entries []entry
+}
+
+func newTable(n int) table {
+	return table{n: n, entries: make([]entry, n*n)}
+}
+
+func (t table) at(i, j int) entry     { return t.entries[i*t.n+j] }
+func (t table) set(i, j int, e entry) { t.entries[i*t.n+j] = e }
+
+

--- a/matnum/vector.go
+++ b/matnum/vector.go
@@ -1,0 +1,74 @@
+package matnum
+
+var(
+	vec *Vector
+	_ Matrix = vec
+)
+
+type Vector struct {
+
+}
+
+func (*Vector) Dims() (dim int) {
+	panic("implement me")
+}
+
+func (*Vector) Shape() int {
+	panic("implement me")
+}
+
+func (*Vector) shape() (shapes []int) {
+	panic("implement me")
+}
+
+func (*Vector) at(paras ...int) float64 {
+	panic("implement me")
+}
+func (*Vector) At(i int) float64 {
+	panic("implement me")
+}
+
+func (*Vector) set(val float64, paras ...int) {
+	panic("implement me")
+}
+
+func (*Vector) T() Matrix {
+	panic("implement me")
+}
+
+func (*Vector) Mul(matrixs ...Matrix) Matrix {
+	panic("implement me")
+}
+
+func (*Vector) Add(matrixs ...Matrix) Matrix {
+	panic("implement me")
+}
+
+func (*Vector) Scale(scale float64) Matrix {
+	panic("implement me")
+}
+
+func (*Vector) Clone() Matrix {
+	panic("implement me")
+}
+
+func (*Vector) copyTo(mat Matrix) {
+
+}
+
+func (*Vector) Slice(paras ...[2]int) Matrix {
+	panic("implement me")
+}
+
+func (*Vector) apply(fn func(fn_e func(elem float64) float64, elems ...int) float64,fn2 func(elem float64) float64, val float64) {
+	panic("implement me")
+}
+
+func (*Vector) appendMatrix(matrix Matrix, flags ...int) Matrix {
+	panic("implement me")
+}
+
+func (*Vector) Err() error {
+	panic("implement me")
+}
+


### PR DESCRIPTION
I add the new package matnum to improve the matrix operation ,it's easy to use ,but beta,i want to know that why author use type Transpose and type UnTranspose, it is hard to use
and the list of this code also made be confused:


	aU, _ := untranspose(a)
	bU, _ := untranspose(b)
	m.reuseAs(ar, ac)

	if arm, ok := a.(RawMatrixer); ok {
		if brm, ok := b.(RawMatrixer); ok {
			amat, bmat := arm.RawMatrix(), brm.RawMatrix()
			if m != aU {
				m.checkOverlap(amat)
			}
			if m != bU {
				m.checkOverlap(bmat)
			}
			for ja, jb, jm := 0, 0, 0; ja < ar*amat.Stride; ja, jb, jm = ja+amat.Stride, jb+bmat.Stride, jm+m.mat.Stride {
				for i, v := range amat.Data[ja : ja+ac] {
					m.mat.Data[i+jm] = v * bmat.Data[i+jb]
				}
			}
			return
		}
	}

	var restore func()
	if m == aU {
		m, restore = m.isolatedWorkspace(aU)
		defer restore()
	} else if m == bU {
		m, restore = m.isolatedWorkspace(bU)
		defer restore()
	}
code from dense mul func
i think it's useless